### PR TITLE
Use the previous image's section settings when refreshing.

### DIFF
--- a/js9.js
+++ b/js9.js
@@ -1781,7 +1781,14 @@ JS9.Image.prototype.refreshImage = function(obj, func){
     this.binning.obin = this.binning.bin;
     this.mkRawDataFromHDU(obj);
     dobin = (this.binning.obin !== this.binning.bin);
+    // use the previous image's section settings
+    var image = JS9.GetImage();
+    if( image ) {
+    this.mkSection(image.primary.sect.xcen, image.primary.sect.ycen,
+                   image.primary.sect.zoom);
+    } else {
     this.mkSection();
+    }
     this.displayImage("colors");
     // update shape layers if we changed the binning params
     if( dobin ){


### PR DESCRIPTION
Hi Eric,

I've been having this issue where the zooming functionality doesn't appear to work 100% so I took some time to look into it. What seems to happen is that the `sect` stuff on `image.primary` reverts back to the initial values every time the image is refreshed.

What I've done is to try and grab a reference to the previous image and use those if they are available. You'll have to review the code to make sure I haven't done anything wrong though.