### PR TITLE
Use https access to HEASARC

### DIFF
--- a/help/archives.html
+++ b/help/archives.html
@@ -16,7 +16,7 @@
 <center><h3>Data Archives That Can Generate FITS URLs For Use With JS9</h3></center>
 <ul>
 <li> <a href="http://skyview.gsfc.nasa.gov/current/cgi/query.pl" target="_blank" rel="noopener noreferrer">NASA/HEASARC SkyView</a>: in the search results, copy the FITS URL from the <i>Download FITS or quick look jpeg image</i> option.
-<li> <a href="http://heasarc.gsfc.nasa.gov/cgi-bin/W3Browse/w3browse.pl" target="_blank" rel="noopener noreferrer">NASA/HEASARC Browse</a>: in the Browse Query Results, the <i>D</i> option ("Preview data products for this row") in the <i>Services</i> column will give FITS URLs.
+<li> <a href="https://heasarc.gsfc.nasa.gov/cgi-bin/W3Browse/w3browse.pl" target="_blank" rel="noopener noreferrer">NASA/HEASARC Browse</a>: in the Browse Query Results, the <i>D</i> option ("Preview data products for this row") in the <i>Services</i> column will give FITS URLs.
 <li> <a href="https://www.cfa.harvard.edu/archive/chandra/search" target="_blank" rel="noopener noreferrer">The Unofficial Chandra Archive</a>: in the search results, copy a small image URL from the <i>Title</i> or click <i>ObsId</i> to get the Chandra FTP directory for this observation. The *.evt2.fits.gz file contains the event table.
 </ul>
 

--- a/help/helper.html
+++ b/help/helper.html
@@ -133,7 +133,7 @@ The build of the JS9 tpos program also requires the cfitsio library
 library. It is available from NASA/HEASARC at the Goddard Space Flight
 Center:
 <pre>
-    http://heasarc.gsfc.nasa.gov/fitsio/fitsio.html
+    https://heasarc.gsfc.nasa.gov/fitsio/fitsio.html
 </pre>
 To tell configure where cfitsio libraries and executables are
 located, use the --with-cfitsio=[dir] switch,

--- a/help/yourdata.html
+++ b/help/yourdata.html
@@ -52,7 +52,7 @@ will display display all photons in the EVENTS binary table having the
 same pi and pha values. Cfitsio also supports display of arbitrary
 image extensions, gzip'ed files, tile compressed files, image
 sections, etc.  See the
- <a href="http://heasarc.gsfc.nasa.gov/docs/software/fitsio/c/c_user/cfitsio.html">
+ <a href="https://heasarc.gsfc.nasa.gov/docs/software/fitsio/c/c_user/cfitsio.html">
 cfitsio documentation</a> for more information.
 
 <p>

--- a/index.html
+++ b/index.html
@@ -380,7 +380,7 @@
       FITS and PNG files.
       <p>
       <b>Release 1.3 (3/30/15)</b> incorporates the standard
-      <a href="http://heasarc.gsfc.nasa.gov/docs/software/fitsio/" target="_blank" rel="noopener noreferrer">cfitsio</a>
+      <a href="https://heasarc.gsfc.nasa.gov/docs/software/fitsio/" target="_blank" rel="noopener noreferrer">cfitsio</a>
       FITS library, using Emscripten to compile to JavaScript.
       <p>
       <b>Release 1.2 (1/4/15)</b> adds support for the new
@@ -408,7 +408,7 @@
       <p>
       To configure a back-end Node helper (for server-side analysis and
       external control), you also will need to install the
-      <a href="http://heasarc.gsfc.nasa.gov/docs/software/fitsio" target="_blank" rel="noopener noreferrer">cfitsio</a>
+      <a href="https://heasarc.gsfc.nasa.gov/docs/software/fitsio" target="_blank" rel="noopener noreferrer">cfitsio</a>
       library.
       <p>
       Tar files:
@@ -442,7 +442,7 @@
       <li> appcropolis  for double click support (http://appcropolis.com/blog/howto/implementing-doubletap-on-iphones-and-ipads/)
       <li> spin.js for spinner support (http://spin.js.org/)
       <li> Marc J Schmidt for CSS element queries (https://github.com/marcj/css-element-queries)
-      <li> HEASARC for CFITSIO lib (http://heasarc.gsfc.nasa.gov/fitsio/)
+      <li> HEASARC for CFITSIO lib (https://heasarc.gsfc.nasa.gov/fitsio/)
       <li> IPAC for Montage (http://montage.ipac.caltech.edu/)
       <li> SAO/TDC for WCS lib (http://tdc-www.harvard.edu/wcstools/)
       </ul>

--- a/plugins/fitsy/binning.html
+++ b/plugins/fitsy/binning.html
@@ -74,7 +74,7 @@ then the following are valid expressions:
 <p>
 NB: when using cfitsio (the default, instead of fitsy.js), table
 filtering follows cfitsio conventions, which is documented
-<a href="http://heasarc.gsfc.nasa.gov/docs/software/fitsio/c/c_user/node97.html">here</a>.
+<a href="https://heasarc.gsfc.nasa.gov/docs/software/fitsio/c/c_user/node97.html">here</a>.
 
 <p>
 NB: the range list support described below works only when using


### PR DESCRIPTION
HEASARC is moving to using https access only - as discussed at https://heasarc.gsfc.nasa.gov/docs/https.html - so this commit explicitly uses https rather than http in HEASARC URIs. It's not absolutely necessary, since the http URIs should be automatically redirected, but it seems like a good idea.