### PR TITLE
Add api links to the HTML documentation

### DIFF
--- a/help/publicapi.html
+++ b/help/publicapi.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <meta charset="UTF-8">
 <title>The JS9 Public API</title>
-<style type="text/css">
+<style>
   .container{
     padding: 10px;
   }
@@ -55,7 +55,7 @@ or
 <a href="#JS9.PixToWCS">JS9.PixtoWCS()</a>:
 <pre>
     var im = JS9.GetImage({display: "myJS9"});
-    for(i=0; i<1000; i++){
+    for(i=0; i&lt;1000; i++){
       x = ...
       y = ... 
       wcs = JS9.PixtoWCS(x, y, {display: im});
@@ -93,12 +93,12 @@ Choose from the following sections:
 <li><a href="#displays">Working with Displays</a>
 <li><a href="#misc">Miscellaneous</a>
 <li><a href="#proto">Prototypes (in development)</a>
+<li><a href="#history">API Change History</a>
 </ul>
 
-<p><hr><p>
-<center><b><font size="+1">
-<a name="load">Loading Images</a>
-</font></b></center>
+<p><hr>
+<p id="load">
+<center><b><font size="+1">Loading Images</font></b></center>
 
 <p id="JS9.Load">
 <font size="+1"><b><u>Load an image into JS9</u></b></font>
@@ -332,10 +332,9 @@ Thus, to check for image load, one can do this in python:
     j.SetZoom(2)
 </pre>
 
-<p><hr><p>
-<center><b><font size="+1">
-<a name="images">Working with Images</a>
-</font></b></center>
+<p><hr>
+<p id="images">
+<center><b><font size="+1">Working with Images</font></b></center>
 <p>
 
 <p id="JS9.GetImage">
@@ -2100,10 +2099,9 @@ the data file need not be in the same location as it was originally: you
 can adjust the path of the data file by editing the <b>file</b> property
 as needed.
 
-<p><hr><p>
-<center><b><font size="+1">
-<a name="regions">Working with Regions</a>
-</font></b></center>
+<p><hr>
+<p id="regions">
+<center><b><font size="+1">Working with Regions</font></b></center>
 <p>
 Spatial regions of interest are a crucial part of astronomical data
 analysis.  The regions layer is a special case of the more generalized
@@ -2466,10 +2464,9 @@ Load the specified regions file into the displayed image. The filename,
 which must be specified, can be a local file (with absolute path or a
 path relative to the displayed web page) or a URL.
 
-<p><hr><p>
-<center><b><font size="+1">
-<a name="shapes">Working with Shape Layers</a>
-</font></b></center>
+<p><hr>
+<p id="shapes">
+<center><b><font size="+1">Working with Shape Layers</font></b></center>
 <p>
 JS9 supports individual layers for drawing 2D graphics. The regions
 layer is a special case of a shape layer, created automatically by
@@ -2947,10 +2944,9 @@ with the current active layer will be saved. In either case, the
 layer to save must actually be a catalog created from a tab-delimited
 file (or URL) of catalog objects (not, for example, the regions layer).
 
-<p><hr><p>
-<center><b><font size="+1">
-<a name="gestures">Mouse/Touch Gestures</a>
-</font></b></center>
+<p><hr>
+<p id="gestures">
+<center><b><font size="+1">Mouse/Touch Gestures</font></b></center>
 <p>
 JS9 supports the following configurable mouse and touch actions:
 <ul>
@@ -3027,15 +3023,13 @@ and/or JS9.globalOpts.touchActions arrays to make it active immediately:
     JS9.globalOpts.mouseActions[1] = "all contrast/bias";
     JS9.globalOpts.touchActions[1] = "all contrast/bias";
 </pre>
-</ul>
 Here, we have replaced the one-button mouse move and two-button touch
 move actions (whose defaults are to "change contrast/bias") with our
 new action.
 
-<p><hr><p>
-<center><b><font size="+1">
-<a name="server">Server-side Analysis</a>
-</font></b></center>
+<p><hr>
+<p id="server">
+<center><b><font size="+1">Server-side Analysis</font></b></center>
 <p>
 
 <p id="JS9.RunAnalysis">
@@ -3124,10 +3118,9 @@ for
 <a href="#JS9.RunAnalysis"><b>JS9.RunAnalysis()</b></a>
 above.
 
-<p><hr><p>
-<center><b><font size="+1">
-<a name="displays">Working with Displays</a>
-</font></b></center>
+<p><hr>
+<p id="displays">
+<center><b><font size="+1">Working with Displays</font></b></center>
 <p>
 
 <p id="JS9.LookupDisplay">
@@ -3280,10 +3273,9 @@ or:
     JS9.CenterDisplay({display: "myJS9"});
 </pre>
 
-<p><hr><p>
-<center><b><font size="+1">
-<a name="misc">Miscellaneous</a>
-</font></b></center>
+<p><hr>
+<p id="misc">
+<center><b><font size="+1">Miscellaneous</font></b></center>
 <p>
 
 <p id="JS9.Print">
@@ -3758,9 +3750,8 @@ In you find you need to call this routine in order make your in-page
 plugins display properly, please let us know the circumstances.
 
 <p><hr>
-<center><b><font size="+1">
-<a name="proto">Prototype Routines (not ready for prime time)</a>
-</font></b></center>
+<p id="proto">
+<center><b><font size="+1">Prototype Routines (not ready for prime time)</font></b></center>
 <p>
 NB: The routines in this section are prototypes and therefore are
 subject to change. Feel free to contact us to discuss your needs so
@@ -3853,10 +3844,9 @@ object. Please contact us if you want to work with auxiliary files, so
 that we can continue to think about what is required for their support.
 
 
-<p><hr><p>
-<center><b><font size="+1">
-<a name="proto">API Change History</a>
-</font></b></center>
+<p><hr>
+<p id="history">
+<center><b><font size="+1">API Change History</font></b></center>
 <p>
 The JS9 Public API is meant to be stable and well-documented. If we are
 forced to make an incompatible change to the API, it will be documented here.
@@ -3906,7 +3896,7 @@ See js9onchange.html for an example of using this callback function.
 
 <p><hr><p>
 
-<h5>Last updated: February 12, 2018</h5>
+<h5>Last updated: February 13, 2018</h5>
 </div>
 
 </body>

--- a/help/publicapi.html
+++ b/help/publicapi.html
@@ -13,7 +13,11 @@
 
   h4 {
     font-size: larger;
-    font-weight: bold;
+  }
+
+  h5 {
+    font-size: larger;
+    text-decoration: underline;
   }
 </style>
 </head>
@@ -108,8 +112,7 @@ Choose from the following sections:
 <p><hr>
 <h4 id="load">Loading Images</h4>
 
-<p id="JS9.Load">
-<font size="+1"><b><u>Load an image into JS9</u></b></font>
+<h5 id="JS9.Load">Load an image into JS9</h5>
 <p> 
 <code><font size="+1">JS9.Load(url, opts)</font></code>
 <p>
@@ -160,8 +163,7 @@ To load an image into a specified display, pass the <b>display object</b> as the
 See <a href="./yourdata.html">Displaying Your Data</a> for further discussion of
 how to use this routine.
 
-<p id="JS9.LoadWindow">
-<font size="+1"><b><u>Load an image into a light window or a new (separate) window</u></b></font>
+<h5 id="JS9.LoadWindow">Load an image into a light window or a new (separate) window</h5>
 <p>
 <code><font size="+1">JS9.LoadWindow(url, opts, type, html, winopts)</font></code>
 <p>
@@ -211,8 +213,7 @@ To create a new light window without loading an image, use:
 <p>
 See js9create.html for examples of how to use this routine.
 
-<p id="JS9.LoadProxy">
-<font size="+1"><b><u>Load an image URL into JS9 using a proxy server</u></b></font>
+<h5 id="JS9.LoadProxy">Load an image URL into JS9 using a proxy server</h5>
 <p> 
 <code><font size="+1">JS9.LoadProxy(url, opts)</font></code>
 <p>
@@ -286,8 +287,7 @@ The main
 <a href="https://js9.si.edu">JS9 web site</a> does support proxy service, and
 can be used to view images from arbitrary URLs.
 
-<p id="JS9.Preload">
-<font size="+1"><b><u>Load one or more images when the web page is ready</u></b></font>
+<h5 id="JS9.Preload">Load one or more images when the web page is ready</h5>
 <p>
 <code><font size="+1">JS9.Preload(url1, opts1, url2, opts2, ... url2, optsn)</font></code>
 <p>
@@ -306,8 +306,7 @@ until the web page is fully loaded, since JS9 itself is not fully
 initialized until then. It is for this reason that <b>JS9.Preload()</b>
 generally is called using an onload routine tied to the web page body.
   
-<p id="JS9.GetLoadStatus">
-<font size="+1"><b><u>Get Load Status</u></b></font>
+<h5 id="JS9.GetLoadStatus">Get Load Status</h5>
 <p> 
 <code><font size="+1">status = JS9.GetLoadStatus(id)</font></code>
 <p>
@@ -343,8 +342,7 @@ Thus, to check for image load, one can do this in python:
 <p><hr>
 <h4 id="images">Working with Images</h4>
 
-<p id="JS9.GetImage">
-<font size="+1"><b><u>Get image handle for the current image</u></b></font>
+<h5 id="JS9.GetImage">Get image handle for the current image</h5>
 <p>
 <code><font size="+1">im = JS9.GetImage()</font></code>
 <p>
@@ -359,8 +357,7 @@ The returned image handle can be passed in the display object.  This
 is marginally more efficient than the default behavior, which is to
 determine the current image for each call.
 
-<p id="JS9.LookupImage">
-<font size="+1"><b><u>Lookup an image by id</u></b></font>
+<h5 id="JS9.LookupImage">Lookup an image by id</h5>
 <p>
 <code><font size="+1">im = JS9.LookupImage(id)</font></code>
 <p>
@@ -394,8 +391,7 @@ you can close foo2.fits this way:
     }
 </pre>
 
-<p id="JS9.GetImageData">
-<font size="+1"><b><u>Get image data and auxiliary info for the specified image</u></b></font>
+<h5 id="JS9.GetImageData">Get image data and auxiliary info for the specified image</h5>
 <p>
 <code><font size="+1">imdata = JS9.GetImageData(dflag)</font></code>
 <p>
@@ -477,8 +473,7 @@ Also note that since we need 0-based data array indexes, we subtract 1 from
 the 1-based image position.  But then we must add 0.5 before rounding because
 by convention, x.0, y.0 is the middle of the pixel.
 
-<p id="JS9.GetDisplayData">
-<font size="+1"><b><u>Get image data for all images loaded into the specified display</u></b></font>
+<h5 id="JS9.GetDisplayData">Get image data for all images loaded into the specified display</h5>
 <p>
 <code><font size="+1">imarr = JS9.GetDisplayData()</font></code>
 <p>
@@ -494,8 +489,7 @@ That is, it returns the same type of information as
 but does so for each image associated
 with the display, not just the current image.
 
-<p id="JS9.DisplayImage">
-<font size="+1"><b><u>Display an image</u></b></font>
+<h5 id="JS9.DisplayImage">Display an image</h5>
 <p>
 <code><font size="+1">JS9.DisplayImage(step)</font></code>
 <p>
@@ -511,8 +505,7 @@ The default step is "primary", which displays the image without recalculating
 color data, scaled data, etc. This generally is what you want, unless you have
 explicitly changed parameter(s) used in a prior step.
 
-<p id="JS9.RefreshImage">
-<font size="+1"><b><u>Re-read the image data and re-display</u></b></font>
+<h5 id="JS9.RefreshImage">Re-read the image data and re-display</h5>
 <p>
 <code><font size="+1">JS9.RefreshImage(input, func)</font></code>
 <p>
@@ -580,8 +573,7 @@ is that the former updates the data into an
 existing image, while the latter adds a completely new image to the
 display.
 
-<p id="JS9.DisplaySection">
-<font size="+1"><b><u>Extract and display a section of a FITS file</u></b></font>
+<h5 id="JS9.DisplaySection">Extract and display a section of a FITS file</h5>
 <p>
 <code><font size="+1">JS9.DisplaySection(opts)</font></code>
 <p>
@@ -673,8 +665,7 @@ deprecated fitsy.js), and therefore follows cfitsio filtering
 conventions, which are documented
 <a href="https://heasarc.gsfc.nasa.gov/docs/software/fitsio/c/c_user/node97.html">here</a>.
 
-<p id="JS9.DisplayExtension">
-<font size="+1"><b><u>Display an extension from a multi-extension FITS file</u></b></font>
+<h5 id="JS9.DisplayExtension">Display an extension from a multi-extension FITS file</h5>
 <p>
 <code><font size="+1">JS9.DisplayExtension(extid, opts)</font></code>
 <p>
@@ -688,8 +679,7 @@ a multi-extension FITS file. (See, for example,
 <a href=" http://fits.gsfc.nasa.gov/fits_primer.html">the FITS Primer</a>
 for information about HDUs and multi-extension FITS).
 
-<p id="JS9.DisplaySlice">
-<font size="+1"><b><u>Display a slice of a FITS data cube</u></b></font>
+<h5 id="JS9.DisplaySlice">Display a slice of a FITS data cube</h5>
 <p>
 <code><font size="+1">JS9.DisplaySlice(slice, opts)</font></code>
 <p>
@@ -734,8 +724,7 @@ the two "files".  Note that the new id and filename are adjusted to be
 the original file's values with the cfitsio image section <b>[6:6,*,*]</b>
 appended.
 
-<p id="JS9.BlendImage">
-<font size="+1"><b><u>Blend the image in an image stack using W3C composite/blend modes </u></b></font>
+<h5 id="JS9.BlendImage">Blend the image in an image stack using W3C composite/blend modes</h5>
 <p>
 <code><font size="+1">JS9.BlendImage(blendMode, opacity)</font></code>
 <p>
@@ -841,8 +830,7 @@ arguments to perform a variety of functions:
 </ul>
 Other actions will be added as we gain experience with blending operations
 
-<p id="JS9.BlendDisplay">
-<font size="+1"><b><u>Set the global image blend more for the specified display</u></b></font>
+<h5 id="JS9.BlendDisplay">Set the global image blend more for the specified display</h5>
 <p>
 <code><font size="+1">mode = JS9.BlendDisplay(true|false)</font></code>
 <p>
@@ -853,8 +841,7 @@ returns:
 This routine will turn on/off the global image blend mode for the specified
 display. If no argument is specified, it returns the current blend mode.
 
-<p id="JS9.CloseImage">
-<font size="+1"><b><u>Clear the image from the display and mark resources for release</u></b></font>
+<h5 id="JS9.CloseImage">Clear the image from the display and mark resources for release</h5>
 <p>
 <code><font size="+1">JS9.CloseImage()</font></code>
 <p>
@@ -871,8 +858,7 @@ accessible to JavaScript programming.
 Some day, all browsers will support full 64-bit addressing and this problem will
 go away ...
 
-<p id="JS9.GetColormap">
-<font size="+1"><b><u>Get the image colormap</u></b></font>
+<h5 id="JS9.GetColormap">Get the image colormap</h5>
 <p>
 <code><font size="+1">cmap = JS9.GetColormap()</font></code>
 <p>
@@ -887,8 +873,7 @@ The returned cmap object will contain the following properties:
 <li><b>bias</b>: bias value (range 0 to 1)
 </ul>
 
-<p id="JS9.SetColormap">
-<font size="+1"><b><u>Set the image colormap</u></b></font>
+<h5 id="JS9.SetColormap">Set the image colormap</h5>
 <p>
 <code><font size="+1">JS9.SetColormap(colormap, [contrast, bias])</font></code>
 <p>
@@ -902,8 +887,7 @@ Set the current colormap, contrast/bias, or both. This call takes one
 (colormap), two (contrast, bias) or three (colormap, contrast, bias)
 arguments.
 
-<p id="JS9.SaveColormap">
-<font size="+1"><b><u>Save current colormap definition</u></b></font>
+<h5 id="JS9.SaveColormap">Save current colormap definition</h5>
 <p>
 <code><font size="+1">JS9.SaveColormap(filename)</font></code>
 <p>
@@ -921,8 +905,7 @@ Don't forget that the file is saved by the browser, in whatever location
 you have set up for downloads.
 </p>
 
-<p id="JS9.AddColormap">
-<font size="+1"><b><u>Add a colormap to JS9</u></b></font>
+<h5 id="JS9.AddColormap">Add a colormap to JS9</h5>
 <p>
 <code><font size="+1">JS9.AddColormap(name, aa|rr,gg,bb|obj|json)</font></code>
 <p>
@@ -999,8 +982,7 @@ Finally, note that <b>JS9.AddColormap()</b> adds its new colormap to
 all JS9 displays on the given page.
 </p>
 
-<p id="JS9.LoadColormap">
-<font size="+1"><b><u>Load a colormap file into JS9</u></b></font>
+<h5 id="JS9.LoadColormap">Load a colormap file into JS9</h5>
 <p>
 <code><font size="+1">JS9.LoadColormap(filename)</font></code>
 <p>
@@ -1071,8 +1053,7 @@ As with
 the new colormap will be available in all displays.
 </p>
 
-<p id="JS9.GetRGBMode">
-<font size="+1"><b><u>Get RGB Mode</u></b></font>
+<h5 id="JS9.GetRGBMode">Get RGB Mode</h5>
 <p>
 <code><font size="+1">JS9.GetRGBMode()</font></code>
 <p>
@@ -1088,8 +1069,7 @@ The returned object will contain the following properties:
 <li><b>bid</b>: image id of "blue" image
 </ul>
 
-<p id="JS9.SetRGBMode">
-<font size="+1"><b><u>Set RGB Mode</u></b></font>
+<h5 id="JS9.SetRGBMode">Set RGB Mode</h5>
 <p>
 <code><font size="+1">JS9.SetRGBMode(mode, [imobj])</font></code>
 <p>
@@ -1122,8 +1102,7 @@ assigned the "red", "green", and "blue" colormaps by another means.
 <p>
 If no arguments are specified, the current RGB mode is toggled;
 
-<p id="JS9.GetScale">
-<font size="+1"><b><u>Get the image scale</u></b></font>
+<h5 id="JS9.GetScale">Get the image scale</h5>
 <p>
 <code><font size="+1">scale = JS9.GetScale()</font></code>
 <p>
@@ -1138,8 +1117,7 @@ The returned scale object will contain the following properties:
 <li><b>scalemax</b>: max value for scaling
 </ul>
 
-<p id="JS9.SetScale">
-<font size="+1"><b><u>Set the image scale</u></b></font>
+<h5 id="JS9.SetScale">Set the image scale</h5>
 <p>
 <code><font size="+1">JS9.SetScale(scale, smin, smax)</font></code>
 <p>
@@ -1153,8 +1131,7 @@ Set the current scale, min/max, or both. This call takes one
 (scale), two (smin, max) or three (scale, smin, smax) arguments. (If "zscale"
 or "zmax" is specified, any supplied smin and smax values are ignored.)
 
-<p id="JS9.GetZoom">
-<font size="+1"><b><u>Get the image zoom factor</u></b></font>
+<h5 id="JS9.GetZoom">Get the image zoom factor</h5>
 <p>
 <code><font size="+1">zoom = JS9.GetZoom()</font></code>
 <p>
@@ -1164,8 +1141,7 @@ returns:
 </ul>
 Get the zoom factor.
 
-<p id="JS9.SetZoom">
-<font size="+1"><b><u>Set the image zoom factor</u></b></font>
+<h5 id="JS9.SetZoom">Set the image zoom factor</h5>
 <p>
 <code><font size="+1">JS9.SetZoom(zoom)</font></code>
 <p>
@@ -1182,8 +1158,7 @@ The zoom directives are:
 <li><b>toFit|ToFit</b>: zoom to fit image in display
 </ul>
 
-<p id="JS9.GetPan">
-<font size="+1"><b><u>Get the image pan position</u></b></font>
+<h5 id="JS9.GetPan">Get the image pan position</h5>
 <p>
 <code><font size="+1">ipos = JS9.GetPan()</font></code>
 <p>
@@ -1197,8 +1172,7 @@ The returned ipos object will contain the following properties:
 <li><b>y</b>: y image coordinate of center
 </ul>
 
-<p id="JS9.SetPan">
-<font size="+1"><b><u>Set the image pan position</u></b></font>
+<h5 id="JS9.SetPan">Set the image pan position</h5>
 <p>
 <code><font size="+1">JS9.SetPan(x, y)</font></code>
 <p>
@@ -1217,8 +1191,7 @@ and
 to convert between image and WCS coordinates.
 </p>
 
-<p id="JS9.GetParam">
-<font size="+1"><b><u>Get an image parameter value</u></b></font>
+<h5 id="JS9.GetParam">Get an image parameter value</h5>
 <p>
 <code><font size="+1">val = JS9.GetParam(param)</font></code>
 <p>
@@ -1239,8 +1212,7 @@ below in the
 section.
 </p>
 
-<p id="JS9.SetParam">
-<font size="+1"><b><u>Set an image parameter value</u></b></font>
+<h5 id="JS9.SetParam">Set an image parameter value</h5>
 <p>
 <code><font size="+1">ovalue = JS9.SetParam(param, value)</font></code>
 <p>
@@ -1282,8 +1254,7 @@ will temporarily disable execution of the previously defined regions
 onload callback, resetting it to the old value after processing
 is complete.
 
-<p id="JS9.EventToDisplayPos">
-<font size="+1"><b><u>Get the display coordinates from an event</u></b></font>
+<h5 id="JS9.EventToDisplayPos">Get the display coordinates from an event</h5>
 <p>
 <code><font size="+1">dpos = JS9.EventToDisplayPos(evt)</font></code>
 <p>
@@ -1300,8 +1271,7 @@ If you define your own event callbacks, you can use this routine to convert
 the event position to a display position, which can then be used to get the
 image position (see below).
 
-<p id="JS9.DIsplayToImagePos">
-<font size="+1"><b><u>Get the image coordinates from the display coordinates</u></b></font>
+<h5 id="JS9.DIsplayToImagePos">Get the image coordinates from the display coordinates</h5>
 <p>
 <code><font size="+1">ipos = JS9.DisplayToImagePos(dpos)</font></code>
 <p>
@@ -1318,8 +1288,7 @@ coordinate values
 Note that image coordinates are one-indexed, as per FITS conventions, while
 display coordinate are 0-indexed.
 
-<p id="JS9.ImageToDisplayPos">
-<font size="+1"><b><u>Get the display coordinates from the image coordinates</u></b></font>
+<h5 id="JS9.ImageToDisplayPos">Get the display coordinates from the image coordinates</h5>
 <p>
 <code><font size="+1">dpos = JS9.ImageToDisplayPos(ipos)</font></code>
 <p>
@@ -1337,8 +1306,7 @@ Get display (screen) coordinates from image coordinates.  Note that
 image coordinates are one-indexed, as per FITS conventions, while
 display coordinate are 0-indexed.
 
-<p id="JS9.LogicalToImagePos">
-<font size="+1"><b><u>Get the image coordinates from the logical coordinates</u></b></font>
+<h5 id="JS9.LogicalToImagePos">Get the image coordinates from the logical coordinates</h5>
 <p>
 <code><font size="+1">ipos = JS9.LogicalToImagePos(lpos, lcs)</font></code>
 <p>
@@ -1362,8 +1330,7 @@ This routine will convert from logical to image coordinates. By default, the
 current logical coordinate system is used. You can specify a different logical
 coordinate system (assuming the appropriate keywords have been defined).
 
-<p id="JS9.ImageToLogicalPos">
-<font size="+1"><b><u>Get the logical coordinates from the image coordinates</u></b></font>
+<h5 id="JS9.ImageToLogicalPos">Get the logical coordinates from the image coordinates</h5>
 <p>
 <code><font size="+1">lpos = JS9.ImageToLogicalPos(ipos, lcs)</font></code>
 <p>
@@ -1386,8 +1353,7 @@ This routine will convert from image to logical coordinates. By default, the
 current logical coordinate system is used. You can specify a different logical
 coordinate system (assuming the appropriate keywords have been defined).
 
-<p id="JS9.GetValPos">
-<font size="+1"><b><u>Get value/position information</u></b></font>
+<h5 id="JS9.GetValPos">Get value/position information</h5>
 <p>
 <code><font size="+1">valpos = JS9.GetValPos(ipos, display)</font></code>
 <p>
@@ -1421,8 +1387,7 @@ or "physical") for the above px, py values
 <li><b>object</b>: object name of the image from the FITS header
 </ul>
 
-<p id="JS9.SetValPos">
-<font size="+1"><b><u>Set the value/position display mode</u></b></font>
+<h5 id="JS9.SetValPos">Set the value/position display mode</h5>
 <p>
 <code><font size="+1">JS9.SetValPos(mode)</font></code>
 <p>
@@ -1432,8 +1397,7 @@ where:
 </ul>
 Set the display mode of the value/position display for the specified image.
 
-<p id="JS9.GetImageInherit">
-<font size="+1"><b><u>Get the image inherit mode</u></b></font>
+<h5 id="JS9.GetImageInherit">Get the image inherit mode</h5>
 <p>
 <code><font size="+1">inherit = JS9.GetImageInherit()</font></code>
 <p>
@@ -1446,8 +1410,7 @@ a new image grabs the image params (e.g., colormap, scale, zoom, etc.)
 from the currently displayed image. If false, these params are taken
 from the default JS9.imageOpts object.
 
-<p id="JS9.SetImageInherit">
-<font size="+1"><b><u>Set the image inherit mode</u></b></font>
+<h5 id="JS9.SetImageInherit">Set the image inherit mode</h5>
 <p>
 <code><font size="+1">JS9.SetImageInherit(mode)</font></code>
 <p>
@@ -1460,8 +1423,7 @@ a new image grabs the image params (e.g., colormap, scale, zoom, etc.)
 from the currently displayed image. If false, these params are taken
 from the default JS9.imageOpts object.
 
-<p id="JS9.GetWCS">
-<font size="+1"><b><u>Get information about the current WCS</u></b></font>
+<h5 id="JS9.GetWCS">Get information about the current WCS</h5>
 <p>
 <code><font size="+1">wcsobj = JS9.GetWCS()</font></code>
 <p>
@@ -1484,8 +1446,7 @@ with this WCS, if present
 <li><b>radecsys</b>: radecsys value (e.g., "ICRS") from the wcs library
 </ul>
 
-<p id="JS9.SetWCS">
-<font size="+1"><b><u>Set the current WCS</u></b></font>
+<h5 id="JS9.SetWCS">Set the current WCS</h5>
 <p>
 <code><font size="+1">JS9.SetWCS(which)</font></code>
 <p>
@@ -1509,8 +1470,7 @@ with this WCS, if present
 </ul>
 If no argument is supplied, the default WCS is set up.
 
-<p id="JS9.GetWCSUnits">
-<font size="+1"><b><u>Get the current WCS units</u></b></font>
+<h5 id="JS9.GetWCSUnits">Get the current WCS units</h5>
 <p>
 <code><font size="+1">unitsstr = JS9.GetWCSUnits()</font></code>
 <p>
@@ -1520,8 +1480,7 @@ returns:
 </ul>
 Get the current WCS units.
 
-<p id="JS9>SetWCSUnits">
-<font size="+1"><b><u>Set the current WCS units</u></b></font>
+<h5 id="JS9>SetWCSUnits">Set the current WCS units</h5>
 <p>
 <code><font size="+1">JS9.SetWCSUnits(unitsstr)</font></code>
 <p>
@@ -1531,8 +1490,7 @@ where:
 </ul>
 Set the current WCS units.
 
-<p id="JS9.GetWCSSys">
-<font size="+1"><b><u>Get the current World Coordinate System</u></b></font>
+<h5 id="JS9.GetWCSSys">Get the current World Coordinate System</h5>
 <p>
 <code><font size="+1">sysstr = JS9.GetWCSSys()</font></code>
 <p>
@@ -1543,8 +1501,7 @@ returns:
 </ul>
 Get current WCS system.
 
-<p id="JS9.SetWCSSys">
-<font size="+1"><b><u>Set the current World Coordinate System</u></b></font>
+<h5 id="JS9.SetWCSSys">Set the current World Coordinate System</h5>
 <p>
 <code><font size="+1">JS9.SetWCSSys(sysstr)</font></code>
 <p>
@@ -1560,8 +1517,7 @@ mainly used in X-ray astronomy where individually detected photon
 events are binned into an image, possibly using a blocking factor.
 For optical images, image and physical coordinate usually are identical.
 
-<p id="JS9.PixToWCS">
-<font size="+1"><b><u>Convert image pixel position to WCS position</u></b></font>
+<h5 id="JS9.PixToWCS">Convert image pixel position to WCS position</h5>
 <p>
 <code><font size="+1">wcsobj = JS9.PixToWCS(x, y)</font></code>
 <p>
@@ -1583,8 +1539,7 @@ The wcs object contains the following properties:
 <li><b>str</b>: string of wcs in current system ("[ra] [dec] [sys]")
 </ul>
 
-<p id="JS9.WCSToPix">
-<font size="+1"><b><u>Convert WCS position to image pixel position</u></b></font>
+<h5 id="JS9.WCSToPix">Convert WCS position to image pixel position</h5>
 <p>
 <code><font size="+1">pixobj = JS9.WCSToPix(ra, dec)</font></code>
 <p>
@@ -1604,8 +1559,7 @@ The pixel object contains the following properties:
 <li><b>str</b>: string of pixel values ("[x]" "[y]")
 </ul>
 
-<p id="JS9.DisplayMessage">
-<font size="+1"><b><u>Display a text message</u></b></font>
+<h5 id="JS9.DisplayMessage">Display a text message</h5>
 <p>
 <code><font size="+1">JS9.DisplayMessage(which, text)</font></code>
 <p>
@@ -1618,8 +1572,7 @@ The text string is displayed in the "info" area (usually occupied by the
 valpos display) or the "region" area (where regions are displayed). The
 empty string will clear the previous message.
 
-<p id="JS9.RawDataLayer">
-<font size="+1"><b><u>Create or modify a raw data layer</u></b></font>
+<h5 id="JS9.RawDataLayer">Create or modify a raw data layer</h5>
 <p>
 <code><font size="+1">JS9.RawDataLayer(opts, func)</font></code>
 <p>
@@ -1733,8 +1686,7 @@ To get the currently displayed layer, call the routine with no arguments:
     JS9.RawDataLayer()         # returns "clip"
 </pre>
 
-<p id="JS9.GaussBlurData">
-<font size="+1"><b><u>Gaussian blur of raw data</u></b></font>
+<h5 id="JS9.GaussBlurData">Gaussian blur of raw data</h5>
 <p>
 <code><font size="+1">JS9.GaussBlurData(sigma, opts)</font></code>
 <p>
@@ -1750,8 +1702,7 @@ specified sigma. The routine uses the fast Gaussian blur algorithm
 described <a href="http://blog.ivank.net/fastest-gaussian-blur.html">
 here</a>.
 
-<p id="JS9.ImarithData">
-<font size="+1"><b><u>Perform image arithmetic on raw data</u></b></font>
+<h5 id="JS9.ImarithData">Perform image arithmetic on raw data</h5>
 <p>
 <code><font size="+1">JS9.ImarithData(op, arg1, opts)</font></code>
 <p>
@@ -1812,8 +1763,7 @@ Finally, note that the two images must have the same dimensions. We
 might be able to remove this restriction in the future, although
 it is unclear how one lines up images of different dimensions.
 
-<p id="JS9.ShiftData">
-<font size="+1"><b><u>Shift raw data</u></b></font>
+<h5 id="JS9.ShiftData">Shift raw data</h5>
 <p>
 <code><font size="+1">JS9.ShiftData(x, y, opts)</font></code>
 <p>
@@ -1830,8 +1780,7 @@ cumulative. The routine is used by the Harvard-Smithsonian Center for
 Astrophysics MicroObservatory project interactively to align images
 that are only slightly offset from one another.
 
-<p id="JS9.FilterRGBImage">
-<font size="+1"><b><u>Apply a filter to the RGB image</u></b></font>
+<h5 id="JS9.FilterRGBImage">Apply a filter to the RGB image</h5>
 <p>
 <code><font size="+1">JS9.FilterRGBImage(filter, args)</font></code>
 <p>
@@ -1949,8 +1898,7 @@ With no arguments, the routine returns an array of available filters:
     ["convolve", "luminance", ..., "blur", "emboss", "lighten", "darken"]
 </pre>
 
-<p id="JS9.ReprojectData">
-<font size="+1"><b><u>Reproject an image using a specified WCS</u></b></font>
+<h5 id="JS9.ReprojectData">Reproject an image using a specified WCS</h5>
 <p>
 <code><font size="+1">JS9.ReprojectData(wcsim, opts)</font></code>
 <p>
@@ -2012,8 +1960,7 @@ by JS9.REPROJDIM, currently 2300 x 2300. Even this might be too large
 for iOS devices under certain circumstances, although issues regarding
 memory are evolving rapidly.
 
-<p id="JS9.RotateData">
-<font size="+1"><b><u>Rotate an image around the  WCS CRPIX point</u></b></font>
+<h5 id="JS9.RotateData">Rotate an image around the  WCS CRPIX point</h5>
 <p>
 <code><font size="+1">JS9.RotateData(angle, opts)</font></code>
 <p>
@@ -2031,8 +1978,7 @@ The rotation is performed about the WCS CRPIX1, CRPIX2 point.
 The optional opts object is passed directly to the <b>JS9.ReprojectData()</b>
 routine. See <b>JS9.ReprojectData()</b> above for more information.
 
-<p id="JS9.SaveSession">
-<font size="+1"><b><u>Save an image session to a file</u></b></font>
+<h5 id="JS9.SaveSession">Save an image session to a file</h5>
 <p>
 <code><font size="+1">JS9.SaveSession(session, opts)</font></code>
 <p>
@@ -2075,8 +2021,7 @@ security protocols. In this case, you must edit the session file to
 supply the path (either absolute or relative to the web page) before
 re-loading the session.
 
-<p id="JS9.LoadSession">
-<font size="+1"><b><u>Load a previously saved image session from a file</u></b></font>
+<h5 id="JS9.LoadSession">Load a previously saved image session from a file</h5>
 <p>
 <code><font size="+1">JS9.LoadSession(session)</font></code>
 <p>
@@ -2137,8 +2082,7 @@ any of the following (in order of precedence):
 </ul>
 Thus, it is possible to act on multiple regions at the same time.
 
-<p id="JS9.AddRegions">
-<font size="+1"><b><u>Add one or more regions to the regions layer</u></b></font>
+<h5 id="JS9.AddRegions">Add one or more regions to the regions layer</h5>
 <p>
 <code><font size="+1">id = JS9.AddRegions(rarr, opts)</font></code>
 <p>
@@ -2251,8 +2195,7 @@ etc. You also can double-click on the text child to bring up its
 configuration dialog box and change its color, font, size, text string,
 etc.
 
-<p id="JS9.GetRegions">
-<font size="+1"><b><u>Get information about one or more regions</u></b></font>
+<h5 id="JS9.GetRegions">Get information about one or more regions</h5>
 <p>
 <code><font size="+1">rarr = JS9.GetRegions(regions)</font></code>
 <p>
@@ -2321,8 +2264,7 @@ Also note that since we need 0-based data array indexes, we subtract 1 from
 the 1-based image position.  But then we must add 0.5 before rounding because
 by convention, x.0, y.0 is the middle of the pixel.
 
-<p id="JS9.ChangeRegions">
-<font size="+1"><b><u>Change one or more regions</u></b></font>
+<h5 id="JS9.ChangeRegions">Change one or more regions</h5>
 <p>
 <code><font size="+1">JS9.ChangeRegions(regions, opts)</font></code>
 <p>
@@ -2353,8 +2295,7 @@ section. However, you cannot (yet)
 change the shape itself (e.g. from "box" to "circle"). See js9onchange.html
 for examples of how to use this routine.
 
-<p id="JS9.CopyRegions">
-<font size="+1"><b><u>Copy one or more regions to another image</u></b></font>
+<h5 id="JS9.CopyRegions">Copy one or more regions to another image</h5>
 <p>
 <code><font size="+1">JS9.CopyRegions(to, regions)</font></code>
 <p>
@@ -2379,8 +2320,7 @@ can specify regions using any of the following:
 In this context, a regexp is a string enclosed between "/"
 slashes.e.g. "/foo[1-4]/" will match "foo1", "foo2", "foo3", "foo4";
 
-<p id="JS9.RemoveRegions">
-<font size="+1"><b><u>Remove one or more regions from the region layer</u></b></font>
+<h5 id="JS9.RemoveRegions">Remove one or more regions from the region layer</h5>
 <p>
 <code><font size="+1">JS9.RemoveRegions(regions)</font></code>
 <p>
@@ -2401,8 +2341,7 @@ can specify regions using any of the following:
 In this context, a regexp is a string enclosed between "/"
 slashes.e.g. "/foo[1-4]/" will match "foo1", "foo2", "foo3", "foo4";
 
-<p id="JS9.SaveRegions">
-<font size="+1"><b><u>Save regions from the current image to a file</u></b></font>
+<h5 id="JS9.SaveRegions">Save regions from the current image to a file</h5>
 <p>
 <code><font size="+1">JS9.SaveRegions(filename, which, layer)</font></code>
 <p>
@@ -2432,8 +2371,7 @@ layer, e.g., if you want to save a catalog layer as a region file
 <a href="#JS9.SaveCatalog"><b>SaveCatalog()</b></a>
 will save the data in table format instead of as regions).
 
-<p id="JS9.ToggleRegionTags">
-<font size="+1"><b><u>Toggle region tags from the current image</u></b></font>
+<h5 id="JS9.ToggleRegionTags">Toggle region tags from the current image</h5>
 <p>
 <code><font size="+1">JS9.ToggleRegionTags(which, t1, t2)</font></code>
 <p>
@@ -2458,8 +2396,7 @@ or vice-versa, depending on the state of the region, while:
 </pre>
 will toggle between <b>include</b> and <b>exclude</b>.
 
-<p id="JS9.LoadRegions">
-<font size="+1"><b><u>Load regions from a file into the current image</u></b></font>
+<h5 id="JS9.LoadRegions">Load regions from a file into the current image</h5>
 <p>
 <code><font size="+1">JS9.LoadRegions(filename)</font></code>
 <p>
@@ -2499,8 +2436,7 @@ be any of the following (in order of precedence):
 </ul>
 Thus, it is possible to act on multiple shapes at the same time.
 
-<p id="JS9.NewShapeLayer">
-<font size="+1"><b><u>Create a new shape layer</u></b></font>
+<h5 id="JS9.NewShapeLayer">Create a new shape layer</h5>
 <p>
 <code><font size="+1">lid = JS9.NewShapeLayer(layer, opts)</font></code>
 <p>
@@ -2613,8 +2549,7 @@ generated tooltip will display current image id in bold, followed by
 that object's x,y pixel position, followed by a user <b>tag</b>
 property passed in the <b>data</b> object when the shape was added.
 
-<p id="JS9.ShowShapeLayer">
-<font size="+1"><b><u>Show or hide the specified shape layer</u></b></font>
+<h5 id="JS9.ShowShapeLayer">Show or hide the specified shape layer</h5>
 <p>
 <code><font size="+1">JS9.ShowShapeLayer(layer, mode)</font></code>
 <p>
@@ -2627,8 +2562,7 @@ Shape layers can be hidden from display. This could be useful, for
 example, if you have several catalogs loaded into a display and
 want to view one at a time.
 
-<p id="JS9.ActiveShapeLayer">
-<font size="+1"><b><u>Make the specified shape layer the active layer</u></b></font>
+<h5 id="JS9.ActiveShapeLayer">Make the specified shape layer the active layer</h5>
 <p>
 <code><font size="+1">JS9.ActiveShapeLayer(layer)</font></code>
 <p>
@@ -2659,8 +2593,7 @@ This routine forms the basis for the <b>Shape Layer</b> plugin, which
 provides a graphical way to make a layer active (by moving it to the
 top of the layer stack).
 
-<p id="JS9.AddShapes">
-<font size="+1"><b><u>Add one or more shapes to the specified layer</u></b></font>
+<h5 id="JS9.AddShapes">Add one or more shapes to the specified layer</h5>
 <p>
 <code><font size="+1">JS9.AddShapes(layer, sarr, opts)</font></code>
 <p>
@@ -2722,8 +2655,7 @@ Deprecated properties:
 <li><b>fixinplace</b>: opposite of changeable
 </ul>
 
-<p id="JS9.RemoveShapes">
-<font size="+1"><b><u>Remove one or more shapes from the specified shape layer</u></b></font>
+<h5 id="JS9.RemoveShapes">Remove one or more shapes from the specified shape layer</h5>
 <p>
 <code><font size="+1">JS9.RemoveShapes(layer, shapes)</font></code>
 <p>
@@ -2733,8 +2665,7 @@ where:
 <li><b>shapes</b>: which shapes to remove
 </ul>
 
-<p id="JS9.GetShapes">
-<font size="+1"><b><u>Get information about one or more shapes in the specified shape layer</u></b></font>
+<h5 id="JS9.GetShapes">Get information about one or more shapes in the specified shape layer</h5>
 <p>
 <code><font size="+1">JS9.GetShapes(layer, shapes)</font></code>
 <p>
@@ -2766,8 +2697,7 @@ Each returned shape object contains the following properties:
 <li><b>data</b>: data property passed in options object when this shape was created.
 </ul>
 
-<p id="JS9.ChangeShapes">
-<font size="+1"><b><u>Change one or more shapes in the specified layer</u></b></font>
+<h5 id="JS9.ChangeShapes">Change one or more shapes in the specified layer</h5>
 <p>
 <code><font size="+1">JS9.ChangeShapes(layer, shapes, opts)</font></code>
 <p>
@@ -2783,8 +2713,7 @@ described in the
 section. However, you cannot (yet)
 change the shape itself (e.g. from "box" to "circle").
 
-<p id="JS9.LoadCatalog">
-<font size="+1"><b><u>Load an astronomical catalog</u></b></font>
+<h5 id="JS9.LoadCatalog">Load an astronomical catalog</h5>
 <p>
 <code><font size="+1">JS9.LoadCatalog(layer, table, opts)</font></code>
 <p>
@@ -2929,8 +2858,7 @@ When catalog layer has been created, you can use the <b>Shape Layers</b>
 plugin to toggle its visibility and also to change its position in the layer
 stack.
 
-<p id="JS9.SaveCatalog">
-<font size="+1"><b><u>Save an astronomical catalog to a file</u></b></font>
+<h5 id="JS9.SaveCatalog">Save an astronomical catalog to a file</h5>
 <p>
 <code><font size="+1">JS9.SaveCatalog(filename, which)</font></code>
 <p>
@@ -3040,8 +2968,7 @@ new action.
   
 <h4 id="server">Server-side Analysis</h4>
 
-<p id="JS9.RunAnalysis">
-<font size="+1"><b><u>Run a simple server-side analysis task</u></b></font>
+<h5 id="JS9.RunAnalysis">Run a simple server-side analysis task</h5>
 <p>
 <code><font size="+1">JS9.RunAnalysis(name, parr, func)</font></code>
 <p>
@@ -3102,9 +3029,8 @@ property <b>JS9.globalOpts.analysisDiv</b> to the id of your new
 target div. The div must have CSS height and width properties if you
 are going to plot results.
 
-<p id="JS9.SubmitAnalysis">
-<font size="+1"><b><u>Run a server-side analysis task, utilizing
-parameters in a form</u></b></font>
+<h5 id="JS9.SubmitAnalysis">Run a server-side analysis task, utilizing
+parameters in a form</h5>
 <p>
 <code><font size="+1">JS9.SubmitAnalysis(el, name, func)</font></code>
 <p>
@@ -3130,8 +3056,7 @@ above.
   
 <h4 id="displays">Working with Displays</h4>
 
-<p id="JS9.LookupDisplay">
-<font size="+1"><b><u>Lookup a JS9 display</u></b></font>
+<h5 id="JS9.LookupDisplay">Lookup a JS9 display</h5>
 <p>
 <code><font size="+1">dobj = JS9.LookupDisplay(dname, mustExist)</font></code>
 <p>
@@ -3152,8 +3077,7 @@ If <b>dname</b> is specified but does not exist, an error is thrown unless
 the <b>mustExist</b> parameter is explicitly set to false (i.e., the default
 is that the id must exist).
 
-<p id="JS9.ResizeDisplay">
-<font size="+1"><b><u>Resize the JS9 Display</u></b></font>
+<h5 id="JS9.ResizeDisplay">Resize the JS9 Display</h5>
 </p>
 <p>
 <code><font size="+1">JS9.ResizeDisplay(dname, width, height, opts)</font></code>
@@ -3202,8 +3126,7 @@ or:
     JS9.ResizeDisplay(350, 400, {display: "myJS9"});
 </pre>
 
-<p id="JS9.MoveToDisplay">
-<font size="+1"><b><u>Move an image to a new JS9 display</u></b></font>
+<h5 id="JS9.MoveToDisplay">Move an image to a new JS9 display</h5>
 <p>
 <code><font size="+1">JS9.MoveToDisplay(dname)</font></code>
 <p>
@@ -3225,8 +3148,7 @@ created with the
 public access routine or
 the <b>File:new JS9 light window</b> menu option.
 
-<p id="JS9.GatherDisplay">
-<font size="+1"><b><u>Gather other images to this JS9 Display</u></b></font>
+<h5 id="JS9.GatherDisplay">Gather other images to this JS9 Display</h5>
 <p>
 <code><font size="+1">JS9.GatherDisplay(dname)</font></code>
 <p>
@@ -3245,8 +3167,7 @@ or:
     JS9.GatherDisplay({display: "myJS9"});
 </pre>
 
-<p id="JS9.SeparateDisplay">
-<font size="+1"><b><u>Separate images in this JS9 Display into new displays</u></b></font>
+<h5 id="JS9.SeparateDisplay">Separate images in this JS9 Display into new displays</h5>
 <p>
 <code><font size="+1">JS9.SeparateDisplay(dname)</font></code>
 <p>
@@ -3265,8 +3186,7 @@ or:
     JS9.SeparateDisplay({display: "myJS9"});
 </pre>
 
-<p id="JS9.CenterDisplay">
-<font size="+1"><b><u>Scroll the JS9 display to the center of the viewport</u></b></font>
+<h5 id="JS9.CenterDisplay">Scroll the JS9 display to the center of the viewport</h5>
 <p>
 <code><font size="+1">JS9.CenterDisplay(dname)</font></code>
 <p>
@@ -3284,8 +3204,7 @@ or:
   
 <h4 id="misc">Miscellaneous</h4>
 
-<p id="JS9.Print">
-<font size="+1"><b><u>Print an image</u></b></font>
+<h5 id="JS9.Print">Print an image</h5>
 <p>
 <code><font size="+1">JS9.Print(opts)</font></code>
 <p>
@@ -3305,8 +3224,7 @@ By default, if a colorbar is active on the page, it will be placed
 beneath the image. You can pass the <b>colorbar: false</b> option
 in the <b>opts</b> object to avoid printing the active colorbar.
 
-<p id="JS9.SaveFITS">
-<font size="+1"><b><u>Save image as a FITS file</u></b></font>
+<h5 id="JS9.SaveFITS">Save image as a FITS file</h5>
 <p>
 <code><font size="+1">JS9.SaveFITS(filename)</font></code>
 <p>
@@ -3321,8 +3239,7 @@ specified, the file will be saved as "js9.fits".
 Don't forget that the file is saved by the browser, in whatever location
 you have set up for downloads.
 
-<p id="JS9.SavePNG">
-<font size="+1"><b><u>Save image as a PNG file</u></b></font>
+<h5 id="JS9.SavePNG">Save image as a PNG file</h5>
 <p>
 <code><font size="+1">JS9.SavePNG(filename)</font></code>
 <p>
@@ -3338,8 +3255,7 @@ along with the graphical overlays (regions, etc.).
 Don't forget that the file is saved by the browser, in whatever location
 you have set up for downloads.
 
-<p id="JS9.SaveJPEG">
-<font size="+1"><b><u>Save image as a JPEG file</u></b></font>
+<h5 id="JS9.SaveJPEG">Save image as a JPEG file</h5>
 <p>
 <code><font size="+1">JS9.SaveJPEG(filename, quality)</font></code>
 <p>
@@ -3358,8 +3274,7 @@ least), this default values is 0.95 (I think).
 Don't forget that the file is saved by the browser, in whatever location
 you have set up for downloads.
 
-<p id="JS9.GetFITSHeader">
-<font size="+1"><b><u>Get FITS header as a string</u></b></font>
+<h5 id="JS9.GetFITSHeader">Get FITS header as a string</h5>
 <p>
 <code><font size="+1">JS9.GetFITSHeader(nlflag)</font></code>
 <p>
@@ -3380,8 +3295,7 @@ obj.BITPIX will have contain the bits/pixel, etc. This object is more
 useful for programming tasks, but does not contain the FITS comments
 associated with each header card.
 
-<p id="JS9.DisplayHelp">
-<font size="+1"><b><u>Display help in a light window</u></b></font>
+<h5 id="JS9.DisplayHelp">Display help in a light window</h5>
 <p>
 <code><font size="+1">JS9.DisplayHelp(name)</font></code>
 <p>
@@ -3393,8 +3307,7 @@ The help file names are the property names in JS9.helpOpts (e.g., "user" for
 the user page, "install" for the install page, etc.). Alternatively, you can
 specify an arbitrary URL to display (just because).
 
-<p id="JS9.DisplayPlugin">
-<font size="+1"><b><u>Display plugin in a light window</u></b></font>
+<h5 id="JS9.DisplayPlugin">Display plugin in a light window</h5>
 <p>
 <code><font size="+1">JS9.DisplayPlugin(name)</font></code>
 <p>
@@ -3432,8 +3345,7 @@ nothing if the plugin is explicitly defined on the web page.
 This routine is useful if you are building a web interface that
 supports the JS9 menu functions.
 
-<p id="JS9.LightWindow">
-<font size="+1"><b><u>Display content in a light window</u></b></font>
+<h5 id="JS9.LightWindow">Display content in a light window</h5>
 <p>
 <code><font size="+1">JS9.LightWindow(id, type, content, title, opts)</font></code>
 <p>
@@ -3481,8 +3393,7 @@ to <b>JS9.LightWindow()</b> or make up your own configuration string.
 As an extension to the Dynamic Drive light window support, JS9 adds the ability
 to double-click the title bar in order to close the window.
 
-<p id="JS9.OpenFileMenu">
-<font size="+1"><b><u>Use the file dialog box to load a FITS file</u></b></font>
+<h5 id="JS9.OpenFileMenu">Use the file dialog box to load a FITS file</h5>
 <p>
 <code><font size="+1">JS9.OpenFileMenu()</font></code>
 <p>
@@ -3492,8 +3403,7 @@ FITS file is selected, if will be loaded into the JS9 display.
 This routine is useful if you are building a web interface that
 supports the JS9 menu functions.
 
-<p id="JS9.OpenRegionsMenu">
-<font size="+1"><b><u>Use the file dialog box to load a region file</u></b></font>
+<h5 id="JS9.OpenRegionsMenu">Use the file dialog box to load a region file</h5>
 <p>
 <code><font size="+1">JS9.OpenRegionsMenu()</font></code>
 <p>
@@ -3503,8 +3413,7 @@ selected, if will be loaded into the JS9 display.
 This routine is useful if you are building a web interface that
 supports the JS9 menu functions.
 
-<p id="JS9.OpenColormapMenu">
-<font size="+1"><b><u>Use the file dialog box to load a colormap file</u></b></font>
+<h5 id="JS9.OpenColormapMenu">Use the file dialog box to load a colormap file</h5>
 <p>
 <code><font size="+1">JS9.OpenColormapMenu()</font></code>
 <p>
@@ -3523,8 +3432,7 @@ supports the JS9 menu functions. See
 <a href="#JS9.AddColormap"><b>JS9.AddColormap()</b></a> for more
 information about colormap formats.
 
-<p id="JS9.GetToolbar">
-<font size="+1"><b><u>Get toolbar values from the Toolbar plugin</u></b></font>
+<h5 id="JS9.GetToolbar">Get toolbar values from the Toolbar plugin</h5>
 <p>
 <code><font size="+1">val = JS9.GetToolbar(type)</font></code>
 <p>
@@ -3541,8 +3449,7 @@ plugin. If the first argument is "showTooltips", the returned value specifies
 whether tooltips are currently displayed. Otherwise an array of tool objects is
 returned, one for each of the defined tools in the toolbar.
 
-<p id="JS9.SetToolbar">
-<font size="+1"><b><u>Set toolbar values for the Toolbar plugin</u></b></font>
+<h5 id="JS9.SetToolbar">Set toolbar values for the Toolbar plugin</h5>
 <p>
 <code><font size="+1">JS9.SetToolbar(arg1, arg2)</font></code>
 <p>
@@ -3635,8 +3542,7 @@ active toolbars by calling:
     JS9.SetToolbar("init");
 </pre>
 
-<p id="JS9.InstalLDir">
-<font size="+1"><b><u>Get location of JS9 installation directory</u></b></font>
+<h5 id="JS9.InstallDir">Get location of JS9 installation directory</h5>
 <p>
 <code><font size="+1">rpath = JS9.InstallDir(file)</font></code>
 <p>
@@ -3653,8 +3559,7 @@ sub-directory. The web page loading the plugin has an arbitrary
 location relative to the JS9 install directory, so this routine
 returns a relative path to the js9 install directory.
 
-<p id="JS9.Send">
-<font size="+1"><b><u>Send a message to a back-end server</u></b></font>
+<h5 id="JS9.Send">Send a message to a back-end server</h5>
 <p>
 <code><font size="+1">JS9.Send(msg, obj, cb)</font></code>
 <p>
@@ -3704,8 +3609,7 @@ list of available analysis tasks and then display this list using the call:
 The "getAnalysis" message passes no parameters to the server. The
 server returns a list of available analysis tasks in json format.
 
-<p id="JS9.AddDivs">
-<font size="+1"><b><u>Add a JS9 display div and/or associated plugins</u></b></font>
+<h5 id="JS9.AddDivs">Add a JS9 display div and/or associated plugins</h5>
 <p>
 <code><font size="+1">JS9.AddDivs(id1, id2, ...)</font></code>
 <p>
@@ -3737,8 +3641,7 @@ See also
 for a nice way to load images into a
 light-weight or completely new window.
 
-<p id="JS9.InstantiatePlugins">
-<font size="+1"><b><u>Instantiate plugins on this web page</u></b></font>
+<h5 id="JS9.InstantiatePlugins">Instantiate plugins on this web page</h5>
 <p>
 <code><font size="+1">JS9.InstantiatePlugins()</font></code>
 <p>
@@ -3764,8 +3667,7 @@ NB: The routines in this section are prototypes and therefore are
 subject to change. Feel free to contact us to discuss your needs so
 that we can gain a better understanding of what is required in these cases.
 
-<p id="JS9.LoadAuxFile">
-<font size="+1"><b><u>Load an auxiliary file</u></b></font>
+<h5 id="JS9.LoadAuxFile">Load an auxiliary file</h5>
 <p>
 <code><font size="+1">JS9.LoadAuxFile(name, func)</font></code>
 <p>

--- a/help/publicapi.html
+++ b/help/publicapi.html
@@ -6,11 +6,20 @@
   .container{
     padding: 10px;
   }
+
+  h3 , h4 {
+    text-align: center;
+  }
+
+  h4 {
+    font-size: larger;
+    font-weight: bold;
+  }
 </style>
 </head>
 <body>
 <div class="container">
-<center><h3>The JS9 Public API</h3></center>
+<h3>The JS9 Public API</h3>
 
 <p>
 The JS9 Public API provides a JavaScript programming interface for
@@ -97,8 +106,7 @@ Choose from the following sections:
 </ul>
 
 <p><hr>
-<p id="load">
-<center><b><font size="+1">Loading Images</font></b></center>
+<h4 id="load">Loading Images</h4>
 
 <p id="JS9.Load">
 <font size="+1"><b><u>Load an image into JS9</u></b></font>
@@ -333,9 +341,7 @@ Thus, to check for image load, one can do this in python:
 </pre>
 
 <p><hr>
-<p id="images">
-<center><b><font size="+1">Working with Images</font></b></center>
-<p>
+<h4 id="images">Working with Images</h4>
 
 <p id="JS9.GetImage">
 <font size="+1"><b><u>Get image handle for the current image</u></b></font>
@@ -2100,8 +2106,9 @@ can adjust the path of the data file by editing the <b>file</b> property
 as needed.
 
 <p><hr>
-<p id="regions">
-<center><b><font size="+1">Working with Regions</font></b></center>
+  
+<h4 id="regions">Working with Regions</h4>
+  
 <p>
 Spatial regions of interest are a crucial part of astronomical data
 analysis.  The regions layer is a special case of the more generalized
@@ -2465,8 +2472,9 @@ which must be specified, can be a local file (with absolute path or a
 path relative to the displayed web page) or a URL.
 
 <p><hr>
-<p id="shapes">
-<center><b><font size="+1">Working with Shape Layers</font></b></center>
+  
+<h4 id="shapes">Working with Shape Layers</h4>
+  
 <p>
 JS9 supports individual layers for drawing 2D graphics. The regions
 layer is a special case of a shape layer, created automatically by
@@ -2945,8 +2953,9 @@ layer to save must actually be a catalog created from a tab-delimited
 file (or URL) of catalog objects (not, for example, the regions layer).
 
 <p><hr>
-<p id="gestures">
-<center><b><font size="+1">Mouse/Touch Gestures</font></b></center>
+  
+<h4 id="gestures">Mouse/Touch Gestures</h4>
+
 <p>
 JS9 supports the following configurable mouse and touch actions:
 <ul>
@@ -3028,9 +3037,8 @@ move actions (whose defaults are to "change contrast/bias") with our
 new action.
 
 <p><hr>
-<p id="server">
-<center><b><font size="+1">Server-side Analysis</font></b></center>
-<p>
+  
+<h4 id="server">Server-side Analysis</h4>
 
 <p id="JS9.RunAnalysis">
 <font size="+1"><b><u>Run a simple server-side analysis task</u></b></font>
@@ -3119,9 +3127,8 @@ for
 above.
 
 <p><hr>
-<p id="displays">
-<center><b><font size="+1">Working with Displays</font></b></center>
-<p>
+  
+<h4 id="displays">Working with Displays</h4>
 
 <p id="JS9.LookupDisplay">
 <font size="+1"><b><u>Lookup a JS9 display</u></b></font>
@@ -3274,9 +3281,8 @@ or:
 </pre>
 
 <p><hr>
-<p id="misc">
-<center><b><font size="+1">Miscellaneous</font></b></center>
-<p>
+  
+<h4 id="misc">Miscellaneous</h4>
 
 <p id="JS9.Print">
 <font size="+1"><b><u>Print an image</u></b></font>
@@ -3750,8 +3756,9 @@ In you find you need to call this routine in order make your in-page
 plugins display properly, please let us know the circumstances.
 
 <p><hr>
-<p id="proto">
-<center><b><font size="+1">Prototype Routines (not ready for prime time)</font></b></center>
+  
+<h4 id="proto">Prototype Routines (not ready for prime time)</h4>
+  
 <p>
 NB: The routines in this section are prototypes and therefore are
 subject to change. Feel free to contact us to discuss your needs so
@@ -3845,8 +3852,9 @@ that we can continue to think about what is required for their support.
 
 
 <p><hr>
-<p id="history">
-<center><b><font size="+1">API Change History</font></b></center>
+  
+<h4 id="history">API Change History</h4>
+  
 <p>
 The JS9 Public API is meant to be stable and well-documented. If we are
 forced to make an incompatible change to the API, it will be documented here.

--- a/help/publicapi.html
+++ b/help/publicapi.html
@@ -1,14 +1,12 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-   "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 <html>
-<head>
-<meta http-equiv="Content-Type" content="text/html;charset=utf-8" >
+<meta charset="UTF-8">
+<title>The JS9 Public API</title>
 <style type="text/css">
   .container{
     padding: 10px;
   }
 </style>
-<title>The JS9 Public API</title>
 </head>
 <body>
 <div class="container">

--- a/help/publicapi.html
+++ b/help/publicapi.html
@@ -49,8 +49,10 @@ property and always is specified as the final argument in a call.
 The display property can specify an image handle instead of a JS9 div
 id. When the image handle in question points to the currently
 displayed image, this alternate usage is nothing more than a trivial
-optimization.  Thus, to call a routine such as JS9.WCSToPix() or
-JS9.PixtoWCS():
+optimization.  Thus, to call a routine such as
+<a href="#JS9.WCSToPix">JS9.WCSToPix()</a>
+or
+<a href="#JS9.PixToWCS">JS9.PixtoWCS()</a>:
 <pre>
     var im = JS9.GetImage({display: "myJS9"});
     for(i=0; i<1000; i++){
@@ -63,7 +65,9 @@ JS9.PixtoWCS():
 However, the image handle does not need to point to the currently
 displayed image. When it does not, the public routine will act on the
 image associated with the image handle, not the current image.  In
-particular, you can use <b>JS9.LookupImage()</b> to get the image
+particular, you can use
+<a href="#JS9.LookupImage"><b>JS9.LookupImage()</b></a>
+to get the image
 handle of any image, and then act on that image. For example, if two
 images, foo1.fits and foo2.fits, are loaded into a JS9 display, and
 foo1.fits is currently being displayed, you can close foo2.fits this way:
@@ -96,7 +100,7 @@ Choose from the following sections:
 <a name="load">Loading Images</a>
 </font></b></center>
 
-<p>
+<p id="JS9.Load">
 <font size="+1"><b><u>Load an image into JS9</u></b></font>
 <p> 
 <code><font size="+1">JS9.Load(url, opts)</font></code>
@@ -122,7 +126,9 @@ Finally, you can pass a fits object containing the following properties:
 <li><b>dmin</b>: data min (optional)
 <li><b>dmax</b>: data max (optional)
 </ul>
-The difference between <b>JS9.RefreshImage()</b> and <b>JS9.Load()</b> is
+The difference between
+<a href="#JS9.RefreshImage"><b>JS9.RefreshImage()</b></a>
+and <b>JS9.Load()</b> is
 that the former updates the data into an existing image, while the latter adds
 a completely new image to the display.
 <p>
@@ -146,7 +152,7 @@ To load an image into a specified display, pass the <b>display object</b> as the
 See <a href="./yourdata.html">Displaying Your Data</a> for further discussion of
 how to use this routine.
 
-<p>
+<p id="JS9.LoadWindow">
 <font size="+1"><b><u>Load an image into a light window or a new (separate) window</u></b></font>
 <p>
 <code><font size="+1">JS9.LoadWindow(url, opts, type, html, winopts)</font></code>
@@ -165,7 +171,8 @@ returns:
 </ul>
 This routine will load an image into a light-weight window or an entirely new
 window. The <b>url</b> and <b>opts</b> arguments are identical to the standard
-<b>JS9.Load()</b> call, except that <b>opts</b> can contain an <b>id</b>
+<a href="#JS9.Load"><b>JS9.Load()</b></a>
+call, except that <b>opts</b> can contain an <b>id</b>
 string to specify the id of the JS9 div being created. If no id is specified,
 a unique id is generated. In either case, the id is returned by the call.
 <p>
@@ -196,7 +203,7 @@ To create a new light window without loading an image, use:
 <p>
 See js9create.html for examples of how to use this routine.
 
-<p>
+<p id="JS9.LoadProxy">
 <font size="+1"><b><u>Load an image URL into JS9 using a proxy server</u></b></font>
 <p> 
 <code><font size="+1">JS9.LoadProxy(url, opts)</font></code>
@@ -271,7 +278,7 @@ The main
 <a href="https://js9.si.edu">JS9 web site</a> does support proxy service, and
 can be used to view images from arbitrary URLs.
 
-<p>
+<p id="JS9.Preload">
 <font size="+1"><b><u>Load one or more images when the web page is ready</u></b></font>
 <p>
 <code><font size="+1">JS9.Preload(url1, opts1, url2, opts2, ... url2, optsn)</font></code>
@@ -291,7 +298,7 @@ until the web page is fully loaded, since JS9 itself is not fully
 initialized until then. It is for this reason that <b>JS9.Preload()</b>
 generally is called using an onload routine tied to the web page body.
   
-<p>
+<p id="JS9.GetLoadStatus">
 <font size="+1"><b><u>Get Load Status</u></b></font>
 <p> 
 <code><font size="+1">status = JS9.GetLoadStatus(id)</font></code>
@@ -331,7 +338,7 @@ Thus, to check for image load, one can do this in python:
 </font></b></center>
 <p>
 
-<p>
+<p id="JS9.GetImage">
 <font size="+1"><b><u>Get image handle for the current image</u></b></font>
 <p>
 <code><font size="+1">im = JS9.GetImage()</font></code>
@@ -347,7 +354,7 @@ The returned image handle can be passed in the display object.  This
 is marginally more efficient than the default behavior, which is to
 determine the current image for each call.
 
-<p>
+<p id="JS9.LookupImage">
 <font size="+1"><b><u>Lookup an image by id</u></b></font>
 <p>
 <code><font size="+1">im = JS9.LookupImage(id)</font></code>
@@ -365,7 +372,8 @@ returns:
 The <b>JS9.LookupImage()</b> routine takes a string id as input and
 returns the image handle of the image having that id (or null). The id
 is the same as is found in the <b>File</b> menu list of displayed images.
-This routine is similar to the standard <b>JS9.GetImage()</b>
+This routine is similar to the standard
+<a href="#JS9.GetImage"><b>JS9.GetImage()</b></a>
 routine, but returns an image by name, regardless of whether it is
 currently being displayed.
 
@@ -381,7 +389,7 @@ you can close foo2.fits this way:
     }
 </pre>
 
-<p>
+<p id="JS9.GetImageData">
 <font size="+1"><b><u>Get image data and auxiliary info for the specified image</u></b></font>
 <p>
 <code><font size="+1">imdata = JS9.GetImageData(dflag)</font></code>
@@ -464,7 +472,7 @@ Also note that since we need 0-based data array indexes, we subtract 1 from
 the 1-based image position.  But then we must add 0.5 before rounding because
 by convention, x.0, y.0 is the middle of the pixel.
 
-<p>
+<p id="JS9.GetDisplayData">
 <font size="+1"><b><u>Get image data for all images loaded into the specified display</u></b></font>
 <p>
 <code><font size="+1">imarr = JS9.GetDisplayData()</font></code>
@@ -476,11 +484,12 @@ returns:
 <p>
 The <b>JS9.GetDisplayData()</b> routine returns an array of image data
 objects, one for each images loaded into the specified display.
-That is, it returns the same type of information
-as <b>JS9.GetImageData()</b>, but does so for each image associated
+That is, it returns the same type of information as
+<a href="#JS9.GetImageData"><b>JS9.GetImageData()</b></a>,
+but does so for each image associated
 with the display, not just the current image.
 
-<p>
+<p id="JS9.DisplayImage">
 <font size="+1"><b><u>Display an image</u></b></font>
 <p>
 <code><font size="+1">JS9.DisplayImage(step)</font></code>
@@ -497,7 +506,7 @@ The default step is "primary", which displays the image without recalculating
 color data, scaled data, etc. This generally is what you want, unless you have
 explicitly changed parameter(s) used in a prior step.
 
-<p>
+<p id="JS9.RefreshImage">
 <font size="+1"><b><u>Re-read the image data and re-display</u></b></font>
 <p>
 <code><font size="+1">JS9.RefreshImage(input, func)</font></code>
@@ -560,12 +569,13 @@ routine. The blob will be passed to the underlying FITS-handler before
 being displayed. Thus, processing time is slightly greater than if you just
 pass the image data directly.
 <p>
-The main difference between <b>JS9.RefreshImage()</b>
-and <b>JS9.Load()</b> is that the former updates the data into an
+The main difference between <b>JS9.RefreshImage()</b> and
+<a href="#JS9.Load"><b>JS9.Load()</b></a>
+is that the former updates the data into an
 existing image, while the latter adds a completely new image to the
 display.
 
-<p>
+<p id="JS9.DisplaySection">
 <font size="+1"><b><u>Extract and display a section of a FITS file</u></b></font>
 <p>
 <code><font size="+1">JS9.DisplaySection(opts)</font></code>
@@ -658,7 +668,7 @@ deprecated fitsy.js), and therefore follows cfitsio filtering
 conventions, which are documented
 <a href="https://heasarc.gsfc.nasa.gov/docs/software/fitsio/c/c_user/node97.html">here</a>.
 
-<p>
+<p id="JS9.DisplayExtension">
 <font size="+1"><b><u>Display an extension from a multi-extension FITS file</u></b></font>
 <p>
 <code><font size="+1">JS9.DisplayExtension(extid, opts)</font></code>
@@ -673,7 +683,7 @@ a multi-extension FITS file. (See, for example,
 <a href=" http://fits.gsfc.nasa.gov/fits_primer.html">the FITS Primer</a>
 for information about HDUs and multi-extension FITS).
 
-<p>
+<p id="JS9.DisplaySlice">
 <font size="+1"><b><u>Display a slice of a FITS data cube</u></b></font>
 <p>
 <code><font size="+1">JS9.DisplaySlice(slice, opts)</font></code>
@@ -719,7 +729,7 @@ the two "files".  Note that the new id and filename are adjusted to be
 the original file's values with the cfitsio image section <b>[6:6,*,*]</b>
 appended.
 
-<p>
+<p id="JS9.BlendImage">
 <font size="+1"><b><u>Blend the image in an image stack using W3C composite/blend modes </u></b></font>
 <p>
 <code><font size="+1">JS9.BlendImage(blendMode, opacity)</font></code>
@@ -778,7 +788,8 @@ and in this <a href="https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API
 
 <p>
 JS9 allows you to use these modes to blend images together. If you load two
-images of the same object into JS9, you can use the <b>JS9.ReprojectData()</b> 
+images of the same object into JS9, you can use the
+<a href="#JS9.ReprojectData"><b>JS9.ReprojectData()</b></a>
 routine to align them by WCS. You then can blend one image into the other by
 specifying a blend mode and an optional opacity. For example, if chandra.fits
 and spitzer.fits are two aligned images of the same object, and chandra.fits is
@@ -825,7 +836,7 @@ arguments to perform a variety of functions:
 </ul>
 Other actions will be added as we gain experience with blending operations
 
-<p>
+<p id="JS9.BlendDisplay">
 <font size="+1"><b><u>Set the global image blend more for the specified display</u></b></font>
 <p>
 <code><font size="+1">mode = JS9.BlendDisplay(true|false)</font></code>
@@ -837,7 +848,7 @@ returns:
 This routine will turn on/off the global image blend mode for the specified
 display. If no argument is specified, it returns the current blend mode.
 
-<p>
+<p id="JS9.CloseImage">
 <font size="+1"><b><u>Clear the image from the display and mark resources for release</u></b></font>
 <p>
 <code><font size="+1">JS9.CloseImage()</font></code>
@@ -855,7 +866,7 @@ accessible to JavaScript programming.
 Some day, all browsers will support full 64-bit addressing and this problem will
 go away ...
 
-<p>
+<p id="JS9.GetColormap">
 <font size="+1"><b><u>Get the image colormap</u></b></font>
 <p>
 <code><font size="+1">cmap = JS9.GetColormap()</font></code>
@@ -871,7 +882,7 @@ The returned cmap object will contain the following properties:
 <li><b>bias</b>: bias value (range 0 to 1)
 </ul>
 
-<p>
+<p id="JS9.SetColormap">
 <font size="+1"><b><u>Set the image colormap</u></b></font>
 <p>
 <code><font size="+1">JS9.SetColormap(colormap, [contrast, bias])</font></code>
@@ -886,7 +897,7 @@ Set the current colormap, contrast/bias, or both. This call takes one
 (colormap), two (contrast, bias) or three (colormap, contrast, bias)
 arguments.
 
-<p>
+<p id="JS9.SaveColormap">
 <font size="+1"><b><u>Save current colormap definition</u></b></font>
 <p>
 <code><font size="+1">JS9.SaveColormap(filename)</font></code>
@@ -903,7 +914,9 @@ colormap.
 <p>
 Don't forget that the file is saved by the browser, in whatever location
 you have set up for downloads.
-<p>
+</p>
+
+<p id="JS9.AddColormap">
 <font size="+1"><b><u>Add a colormap to JS9</u></b></font>
 <p>
 <code><font size="+1">JS9.AddColormap(name, aa|rr,gg,bb|obj|json)</font></code>
@@ -979,8 +992,9 @@ colormap definition:
 <p>
 Finally, note that <b>JS9.AddColormap()</b> adds its new colormap to
 all JS9 displays on the given page.
+</p>
 
-<p>
+<p id="JS9.LoadColormap">
 <font size="+1"><b><u>Load a colormap file into JS9</u></b></font>
 <p>
 <code><font size="+1">JS9.LoadColormap(filename)</font></code>
@@ -993,7 +1007,9 @@ Load the specified colormap file into the web page. The filename,
 which must be specified, can be a local file (with absolute path or a
 path relative to the displayed web page) or a URL. It should contain a
 JSON representation of a colormap, either in RGB color format or in
-vertex format (see <b>JS9.AddColormap()</b> above):
+vertex format (see
+<a href="#JS9.AddColormap"><b>JS9.AddColormap()</b></a>
+above):
 <pre>
     # RGB color format
     {
@@ -1043,10 +1059,14 @@ vertex format (see <b>JS9.AddColormap()</b> above):
       ]
     }
 </pre>
-As with <b>JS9.AddColormap()</b>, the new colormap will be available
-in all displays.
 
 <p>
+As with
+<a href="#JS9.AddColormap"><b>JS9.AddColormap()</b></a>,
+the new colormap will be available in all displays.
+</p>
+
+<p id="JS9.GetRGBMode">
 <font size="+1"><b><u>Get RGB Mode</u></b></font>
 <p>
 <code><font size="+1">JS9.GetRGBMode()</font></code>
@@ -1063,7 +1083,7 @@ The returned object will contain the following properties:
 <li><b>bid</b>: image id of "blue" image
 </ul>
 
-<p>
+<p id="JS9.SetRGBMode">
 <font size="+1"><b><u>Set RGB Mode</u></b></font>
 <p>
 <code><font size="+1">JS9.SetRGBMode(mode, [imobj])</font></code>
@@ -1097,7 +1117,7 @@ assigned the "red", "green", and "blue" colormaps by another means.
 <p>
 If no arguments are specified, the current RGB mode is toggled;
 
-<p>
+<p id="JS9.GetScale">
 <font size="+1"><b><u>Get the image scale</u></b></font>
 <p>
 <code><font size="+1">scale = JS9.GetScale()</font></code>
@@ -1113,7 +1133,7 @@ The returned scale object will contain the following properties:
 <li><b>scalemax</b>: max value for scaling
 </ul>
 
-<p>
+<p id="JS9.SetScale">
 <font size="+1"><b><u>Set the image scale</u></b></font>
 <p>
 <code><font size="+1">JS9.SetScale(scale, smin, smax)</font></code>
@@ -1128,7 +1148,7 @@ Set the current scale, min/max, or both. This call takes one
 (scale), two (smin, max) or three (scale, smin, smax) arguments. (If "zscale"
 or "zmax" is specified, any supplied smin and smax values are ignored.)
 
-<p>
+<p id="JS9.GetZoom">
 <font size="+1"><b><u>Get the image zoom factor</u></b></font>
 <p>
 <code><font size="+1">zoom = JS9.GetZoom()</font></code>
@@ -1139,7 +1159,7 @@ returns:
 </ul>
 Get the zoom factor.
 
-<p>
+<p id="JS9.SetZoom">
 <font size="+1"><b><u>Set the image zoom factor</u></b></font>
 <p>
 <code><font size="+1">JS9.SetZoom(zoom)</font></code>
@@ -1157,7 +1177,7 @@ The zoom directives are:
 <li><b>toFit|ToFit</b>: zoom to fit image in display
 </ul>
 
-<p>
+<p id="JS9.GetPan">
 <font size="+1"><b><u>Get the image pan position</u></b></font>
 <p>
 <code><font size="+1">ipos = JS9.GetPan()</font></code>
@@ -1172,7 +1192,7 @@ The returned ipos object will contain the following properties:
 <li><b>y</b>: y image coordinate of center
 </ul>
 
-<p>
+<p id="JS9.SetPan">
 <font size="+1"><b><u>Set the image pan position</u></b></font>
 <p>
 <code><font size="+1">JS9.SetPan(x, y)</font></code>
@@ -1182,11 +1202,17 @@ where:
 <li><b>x</b>: x image coordinate
 <li><b>y</b>: y image coordinate
 </ul>
-Set the current pan position using image coordinates.  
-Note that you can use <b>JS9.WCSToPix()</b> and <b>JS9.PixToWCS()</b> to
-convert between image and WCS coordinates.
 
 <p>
+Set the current pan position using image coordinates.  
+Note that you can use
+<a href="#JS9.WCSToPix"><b>JS9.WCSToPix()</b></a>
+and
+<a href="#JS9.PixToWCS"><b>JS9.PixToWCS()</b></a>
+to convert between image and WCS coordinates.
+</p>
+
+<p id="JS9.GetParam">
 <font size="+1"><b><u>Get an image parameter value</u></b></font>
 <p>
 <code><font size="+1">val = JS9.GetParam(param)</font></code>
@@ -1200,10 +1226,15 @@ returns:
 <ul>
 <li><b>val</b>: value of the parameter
 </ul>
-Return the value of an image parameter. The available parameters are listed
-below in the <b>SetParam()</b> section.
 
 <p>
+Return the value of an image parameter. The available parameters are listed
+below in the
+<a href="#JS9.SetParam"><b>SetParam()</b></a>
+section.
+</p>
+
+<p id="JS9.SetParam">
 <font size="+1"><b><u>Set an image parameter value</u></b></font>
 <p>
 <code><font size="+1">ovalue = JS9.SetParam(param, value)</font></code>
@@ -1246,7 +1277,7 @@ will temporarily disable execution of the previously defined regions
 onload callback, resetting it to the old value after processing
 is complete.
 
-<p>
+<p id="JS9.EventToDisplayPos">
 <font size="+1"><b><u>Get the display coordinates from an event</u></b></font>
 <p>
 <code><font size="+1">dpos = JS9.EventToDisplayPos(evt)</font></code>
@@ -1264,7 +1295,7 @@ If you define your own event callbacks, you can use this routine to convert
 the event position to a display position, which can then be used to get the
 image position (see below).
 
-<p>
+<p id="JS9.DIsplayToImagePos">
 <font size="+1"><b><u>Get the image coordinates from the display coordinates</u></b></font>
 <p>
 <code><font size="+1">ipos = JS9.DisplayToImagePos(dpos)</font></code>
@@ -1282,7 +1313,7 @@ coordinate values
 Note that image coordinates are one-indexed, as per FITS conventions, while
 display coordinate are 0-indexed.
 
-<p>
+<p id="JS9.ImageToDisplayPos">
 <font size="+1"><b><u>Get the display coordinates from the image coordinates</u></b></font>
 <p>
 <code><font size="+1">dpos = JS9.ImageToDisplayPos(ipos)</font></code>
@@ -1301,7 +1332,7 @@ Get display (screen) coordinates from image coordinates.  Note that
 image coordinates are one-indexed, as per FITS conventions, while
 display coordinate are 0-indexed.
 
-<p>
+<p id="JS9.LogicalToImagePos">
 <font size="+1"><b><u>Get the image coordinates from the logical coordinates</u></b></font>
 <p>
 <code><font size="+1">ipos = JS9.LogicalToImagePos(lpos, lcs)</font></code>
@@ -1326,7 +1357,7 @@ This routine will convert from logical to image coordinates. By default, the
 current logical coordinate system is used. You can specify a different logical
 coordinate system (assuming the appropriate keywords have been defined).
 
-<p>
+<p id="JS9.ImageToLogicalPos">
 <font size="+1"><b><u>Get the logical coordinates from the image coordinates</u></b></font>
 <p>
 <code><font size="+1">lpos = JS9.ImageToLogicalPos(ipos, lcs)</font></code>
@@ -1350,7 +1381,7 @@ This routine will convert from image to logical coordinates. By default, the
 current logical coordinate system is used. You can specify a different logical
 coordinate system (assuming the appropriate keywords have been defined).
 
-<p>
+<p id="JS9.GetValPos">
 <font size="+1"><b><u>Get value/position information</u></b></font>
 <p>
 <code><font size="+1">valpos = JS9.GetValPos(ipos, display)</font></code>
@@ -1385,7 +1416,7 @@ or "physical") for the above px, py values
 <li><b>object</b>: object name of the image from the FITS header
 </ul>
 
-<p>
+<p id="JS9.SetValPos">
 <font size="+1"><b><u>Set the value/position display mode</u></b></font>
 <p>
 <code><font size="+1">JS9.SetValPos(mode)</font></code>
@@ -1396,7 +1427,7 @@ where:
 </ul>
 Set the display mode of the value/position display for the specified image.
 
-<p>
+<p id="JS9.GetImageInherit">
 <font size="+1"><b><u>Get the image inherit mode</u></b></font>
 <p>
 <code><font size="+1">inherit = JS9.GetImageInherit()</font></code>
@@ -1410,7 +1441,7 @@ a new image grabs the image params (e.g., colormap, scale, zoom, etc.)
 from the currently displayed image. If false, these params are taken
 from the default JS9.imageOpts object.
 
-<p>
+<p id="JS9.SetImageInherit">
 <font size="+1"><b><u>Set the image inherit mode</u></b></font>
 <p>
 <code><font size="+1">JS9.SetImageInherit(mode)</font></code>
@@ -1424,7 +1455,7 @@ a new image grabs the image params (e.g., colormap, scale, zoom, etc.)
 from the currently displayed image. If false, these params are taken
 from the default JS9.imageOpts object.
 
-<p>
+<p id="JS9.GetWCS">
 <font size="+1"><b><u>Get information about the current WCS</u></b></font>
 <p>
 <code><font size="+1">wcsobj = JS9.GetWCS()</font></code>
@@ -1448,7 +1479,7 @@ with this WCS, if present
 <li><b>radecsys</b>: radecsys value (e.g., "ICRS") from the wcs library
 </ul>
 
-<p>
+<p id="JS9.SetWCS">
 <font size="+1"><b><u>Set the current WCS</u></b></font>
 <p>
 <code><font size="+1">JS9.SetWCS(which)</font></code>
@@ -1473,7 +1504,7 @@ with this WCS, if present
 </ul>
 If no argument is supplied, the default WCS is set up.
 
-<p>
+<p id="JS9.GetWCSUnits">
 <font size="+1"><b><u>Get the current WCS units</u></b></font>
 <p>
 <code><font size="+1">unitsstr = JS9.GetWCSUnits()</font></code>
@@ -1484,7 +1515,7 @@ returns:
 </ul>
 Get the current WCS units.
 
-<p>
+<p id="JS9>SetWCSUnits">
 <font size="+1"><b><u>Set the current WCS units</u></b></font>
 <p>
 <code><font size="+1">JS9.SetWCSUnits(unitsstr)</font></code>
@@ -1495,7 +1526,7 @@ where:
 </ul>
 Set the current WCS units.
 
-<p>
+<p id="JS9.GetWCSSys">
 <font size="+1"><b><u>Get the current World Coordinate System</u></b></font>
 <p>
 <code><font size="+1">sysstr = JS9.GetWCSSys()</font></code>
@@ -1507,7 +1538,7 @@ returns:
 </ul>
 Get current WCS system.
 
-<p>
+<p id="JS9.SetWCSSys">
 <font size="+1"><b><u>Set the current World Coordinate System</u></b></font>
 <p>
 <code><font size="+1">JS9.SetWCSSys(sysstr)</font></code>
@@ -1524,7 +1555,7 @@ mainly used in X-ray astronomy where individually detected photon
 events are binned into an image, possibly using a blocking factor.
 For optical images, image and physical coordinate usually are identical.
 
-<p>
+<p id="JS9.PixToWCS">
 <font size="+1"><b><u>Convert image pixel position to WCS position</u></b></font>
 <p>
 <code><font size="+1">wcsobj = JS9.PixToWCS(x, y)</font></code>
@@ -1547,7 +1578,7 @@ The wcs object contains the following properties:
 <li><b>str</b>: string of wcs in current system ("[ra] [dec] [sys]")
 </ul>
 
-<p>
+<p id="JS9.WCSToPix">
 <font size="+1"><b><u>Convert WCS position to image pixel position</u></b></font>
 <p>
 <code><font size="+1">pixobj = JS9.WCSToPix(ra, dec)</font></code>
@@ -1568,7 +1599,7 @@ The pixel object contains the following properties:
 <li><b>str</b>: string of pixel values ("[x]" "[y]")
 </ul>
 
-<p>
+<p id="JS9.DisplayMessage">
 <font size="+1"><b><u>Display a text message</u></b></font>
 <p>
 <code><font size="+1">JS9.DisplayMessage(which, text)</font></code>
@@ -1582,7 +1613,7 @@ The text string is displayed in the "info" area (usually occupied by the
 valpos display) or the "region" area (where regions are displayed). The
 empty string will clear the previous message.
 
-<p>
+<p id="JS9.RawDataLayer">
 <font size="+1"><b><u>Create or modify a raw data layer</u></b></font>
 <p>
 <code><font size="+1">JS9.RawDataLayer(opts, func)</font></code>
@@ -1595,7 +1626,8 @@ where:
 Each image has raw data associated with it, i.e. the underlying
 astronomical image pixels that are scaled and displayed using the
 chosen scale and colormap. You can manipulate the raw data by creating
-a new <b>raw data layer</b> using <b>JS9.RawDataLayer()</b>, setting
+a new <b>raw data layer</b> using <b>JS9.RawDataLayer()</b>,
+setting
 the image pixel values, and then making this layer the current
 one. The original raw data (with id "raw0") will be maintained in
 separate layer, so you can switch between layers (also using this
@@ -1674,7 +1706,7 @@ that the addition is cumulative.
 
 <p>
 The oraw and nraw objects contain a subset of the properties returned by
-<b>JS9.GetImageData()</b>:
+<a href="#JS9.GetImageData"><b>JS9.GetImageData()</b></a>:
 <ul>
 <li><b>width</b>: x dimension of image
 <li><b>height</b>: y dimension of image
@@ -1684,7 +1716,8 @@ The oraw and nraw objects contain a subset of the properties returned by
 </ul>
 
 <p>
-To switch to a layer, call <b>JS9.RawDataLayer()</b> with a single argument, the layer name:
+To switch to a layer, call <b>JS9.RawDataLayer()</b>
+with a single argument, the layer name:
 <pre>
     JS9.RawDataLayer("raw0")   # switch to original data
     JS9.RawDataLayer("clip")   # switch to clipped data
@@ -1695,7 +1728,7 @@ To get the currently displayed layer, call the routine with no arguments:
     JS9.RawDataLayer()         # returns "clip"
 </pre>
 
-<p>
+<p id="JS9.GaussBlurData">
 <font size="+1"><b><u>Gaussian blur of raw data</u></b></font>
 <p>
 <code><font size="+1">JS9.GaussBlurData(sigma, opts)</font></code>
@@ -1712,7 +1745,7 @@ specified sigma. The routine uses the fast Gaussian blur algorithm
 described <a href="http://blog.ivank.net/fastest-gaussian-blur.html">
 here</a>.
 
-<p>
+<p id="JS9.ImarithData">
 <font size="+1"><b><u>Perform image arithmetic on raw data</u></b></font>
 <p>
 <code><font size="+1">JS9.ImarithData(op, arg1, opts)</font></code>
@@ -1774,7 +1807,7 @@ Finally, note that the two images must have the same dimensions. We
 might be able to remove this restriction in the future, although
 it is unclear how one lines up images of different dimensions.
 
-<p>
+<p id="JS9.ShiftData">
 <font size="+1"><b><u>Shift raw data</u></b></font>
 <p>
 <code><font size="+1">JS9.ShiftData(x, y, opts)</font></code>
@@ -1792,7 +1825,7 @@ cumulative. The routine is used by the Harvard-Smithsonian Center for
 Astrophysics MicroObservatory project interactively to align images
 that are only slightly offset from one another.
 
-<p>
+<p id="JS9.FilterRGBImage">
 <font size="+1"><b><u>Apply a filter to the RGB image</u></b></font>
 <p>
 <code><font size="+1">JS9.FilterRGBImage(filter, args)</font></code>
@@ -1803,8 +1836,11 @@ where:
 <li><b>args</b>: filter-specific arguments, where applicable
 </ul>
 In JS9, you can change the raw data (and hence the displayed image) using
-routines such as <b>JS9.GaussBlurData()</b> or the more general
-<b>JS9.RawDataLayer()</b>. You also can apply image processing
+routines such as
+<a href="#JS9.GaussBlurData"><b>JS9.GaussBlurData()</b></a>
+or the more general
+<a href="#JS9.RawDataLayer"><b>JS9.RawDataLayer()</b></a>.
+You also can apply image processing
 techniques directly to the displayed RGB image without changing the
 underlying raw data, using this routine. The web has an overwhelming
 amount of information about image processing.  A good technical
@@ -1908,7 +1944,7 @@ With no arguments, the routine returns an array of available filters:
     ["convolve", "luminance", ..., "blur", "emboss", "lighten", "darken"]
 </pre>
 
-<p>
+<p id="JS9.ReprojectData">
 <font size="+1"><b><u>Reproject an image using a specified WCS</u></b></font>
 <p>
 <code><font size="+1">JS9.ReprojectData(wcsim, opts)</font></code>
@@ -1971,7 +2007,7 @@ by JS9.REPROJDIM, currently 2300 x 2300. Even this might be too large
 for iOS devices under certain circumstances, although issues regarding
 memory are evolving rapidly.
 
-<p>
+<p id="JS9.RotateData">
 <font size="+1"><b><u>Rotate an image around the  WCS CRPIX point</u></b></font>
 <p>
 <code><font size="+1">JS9.RotateData(angle, opts)</font></code>
@@ -1981,15 +2017,16 @@ where:
 <li><b>angle</b>: rotation angle in degrees
 <li><b>opts</b>: options object
 </ul>
-The <b>JS9.RotateData()</b> routine using <b>JS9.ReprojectData()</b>
+The <b>JS9.RotateData()</b> routine uses
+<a href="#JS9.ReprojectData"><b>JS9.ReprojectData()</b></a>
 to rotate image data by the specified angle (in degrees). If the string
 "northup" or "northisup" is specified, the rotation angle is set to 0.
 The rotation is performed about the WCS CRPIX1, CRPIX2 point.
 <p>
 The optional opts object is passed directly to the <b>JS9.ReprojectData()</b>
-routine. See <b>JS9.ReprojectData()</b> below for more information.
+routine. See <b>JS9.ReprojectData()</b> above for more information.
 
-<p>
+<p id="JS9.SaveSession">
 <font size="+1"><b><u>Save an image session to a file</u></b></font>
 <p>
 <code><font size="+1">JS9.SaveSession(session, opts)</font></code>
@@ -2033,7 +2070,7 @@ security protocols. In this case, you must edit the session file to
 supply the path (either absolute or relative to the web page) before
 re-loading the session.
 
-<p>
+<p id="JS9.LoadSession">
 <font size="+1"><b><u>Load a previously saved image session from a file</u></b></font>
 <p>
 <code><font size="+1">JS9.LoadSession(session)</font></code>
@@ -2078,12 +2115,16 @@ The regions layer has the special property that, by default,
 its <b>z-index</b> is higher than other shape layers, so that regions
 are displayed on top of other shape layers.
 <p>
-Note that the <b>GetRegions(), ChangeRegions(), RemoveRegions()</b> calls
+Note that the
+<b><a href="#JS9.GetRegions">GetRegions()</a>,
+<a href="#JS9.ChangeRegions">ChangeRegions()</a>,
+<a href="#JS9.RemoveRegions">RemoveRegions()</a></b> calls
 all take a regions specification as the second argument, which can be
 any of the following (in order of precedence):
 <ul>
 <li><b>"all"</b>: all regions
-<li><b>[id]</b>: a specific region id returned by <b>JS9.AddRegions()</b>
+<li><b>[id]</b>: a specific region id returned by
+  <a href="#JS9.AddRegions"><b>JS9.AddRegions()</b></a>
 <li><b>"selected"</b>: the selected region (or all regions in the selected group)
 <li><b>[color]</b>: all regions having the specified color (e.g., "red")
 <li><b>[shape]</b>: all regions having the specified shape (e.g., "circle")
@@ -2091,7 +2132,7 @@ any of the following (in order of precedence):
 </ul>
 Thus, it is possible to act on multiple regions at the same time.
 
-<p>
+<p id="JS9.AddRegions">
 <font size="+1"><b><u>Add one or more regions to the regions layer</u></b></font>
 <p>
 <code><font size="+1">id = JS9.AddRegions(rarr, opts)</font></code>
@@ -2205,7 +2246,7 @@ etc. You also can double-click on the text child to bring up its
 configuration dialog box and change its color, font, size, text string,
 etc.
 
-<p>
+<p id="JS9.GetRegions">
 <font size="+1"><b><u>Get information about one or more regions</u></b></font>
 <p>
 <code><font size="+1">rarr = JS9.GetRegions(regions)</font></code>
@@ -2275,7 +2316,7 @@ Also note that since we need 0-based data array indexes, we subtract 1 from
 the 1-based image position.  But then we must add 0.5 before rounding because
 by convention, x.0, y.0 is the middle of the pixel.
 
-<p>
+<p id="JS9.ChangeRegions">
 <font size="+1"><b><u>Change one or more regions</u></b></font>
 <p>
 <code><font size="+1">JS9.ChangeRegions(regions, opts)</font></code>
@@ -2301,11 +2342,13 @@ slashes.e.g. "/foo[1-4]/" will match "foo1", "foo2", "foo3", "foo4";
 
 <p>
 The opts object can contain the parameters 
-described in the <b>JS9.AddRegions()</b> section. However, you cannot (yet)
+described in the
+<a href="#JS9.AddRegions"><b>JS9.AddRegions()</b></a>
+section. However, you cannot (yet)
 change the shape itself (e.g. from "box" to "circle"). See js9onchange.html
 for examples of how to use this routine.
 
-<p>
+<p id="JS9.CopyRegions">
 <font size="+1"><b><u>Copy one or more regions to another image</u></b></font>
 <p>
 <code><font size="+1">JS9.CopyRegions(to, regions)</font></code>
@@ -2331,7 +2374,7 @@ can specify regions using any of the following:
 In this context, a regexp is a string enclosed between "/"
 slashes.e.g. "/foo[1-4]/" will match "foo1", "foo2", "foo3", "foo4";
 
-<p>
+<p id="JS9.RemoveRegions">
 <font size="+1"><b><u>Remove one or more regions from the region layer</u></b></font>
 <p>
 <code><font size="+1">JS9.RemoveRegions(regions)</font></code>
@@ -2353,7 +2396,7 @@ can specify regions using any of the following:
 In this context, a regexp is a string enclosed between "/"
 slashes.e.g. "/foo[1-4]/" will match "foo1", "foo2", "foo3", "foo4";
 
-<p>
+<p id="JS9.SaveRegions">
 <font size="+1"><b><u>Save regions from the current image to a file</u></b></font>
 <p>
 <code><font size="+1">JS9.SaveRegions(filename, which, layer)</font></code>
@@ -2380,10 +2423,11 @@ a tag value to save regions having that tag.
 If the <b>layer</b> argument is not specified, it defaults to
 "regions", i.e.  the usual regions layer. You can specify a different
 layer, e.g., if you want to save a catalog layer as a region file
-(since <b>SaveCatalog()</b> will save the data in table format instead
-of as regions).
+(since
+<a href="#JS9.SaveCatalog"><b>SaveCatalog()</b></a>
+will save the data in table format instead of as regions).
 
-<p>
+<p id="JS9.ToggleRegionTags">
 <font size="+1"><b><u>Toggle region tags from the current image</u></b></font>
 <p>
 <code><font size="+1">JS9.ToggleRegionTags(which, t1, t2)</font></code>
@@ -2394,7 +2438,8 @@ where:
 <li><b>t1</b>: tag#1
 <li><b>t2</b>: tag#2
 </ul>
-While region tags can be changed using the <b>ChangeRegions()</b> routine, a
+While region tags can be changed using the
+<a href="#JS9.ChangeRegions"><b>ChangeRegions()</b></a> routine, a
 bespoke user interface might want to toggle between a <b>source</b>
 region and <b>background</b> region, or between <b>include</b> and
 <b>exclude</b>. This convenience routine will do that. For example:
@@ -2408,7 +2453,7 @@ or vice-versa, depending on the state of the region, while:
 </pre>
 will toggle between <b>include</b> and <b>exclude</b>.
 
-<p>
+<p id="JS9.LoadRegions">
 <font size="+1"><b><u>Load regions from a file into the current image</u></b></font>
 <p>
 <code><font size="+1">JS9.LoadRegions(filename)</font></code>
@@ -2432,12 +2477,16 @@ JS9. The Catalog plugin creates a separate layer for each catalog.
 You can define your own shape layer using the <b>NewShapeLayer()</b>
 call and then add geometric shapes to it.
 <p>
-Note that the <b>JS9.GetShapes(), JS9.ChangeShapes(), JS9.RemoveShapes()</b> 
+Note that the
+<b><a href="#JS9.GetShapes">JS9.GetShapes()</a>,
+<a href="#JS9.ChangeShapes">JS9.ChangeShapes()</a>,
+<a href="#JS9.RemoveShapes">JS9.RemoveShapes()</a></b> 
 calls all take a shape specification as the second argument, which can
 be any of the following (in order of precedence):
 <ul>
 <li><b>"all"</b>: all regions
-<li><b>[id]</b>: a specific region id returned by <b>JS9.AddRegions()</b>
+<li><b>[id]</b>: a specific region id returned by
+  <a href="#JS9.AddShapes"><b>JS9.AddShapes()</b></a>
 <li><b>"selected"</b>: the selected region (or all regions in the selected group)
 <li><b>[color]</b>: all regions having the specified color (e.g., "red")
 <li><b>[shape]</b>: all regions having the specified shape (e.g., "circle")
@@ -2445,7 +2494,7 @@ be any of the following (in order of precedence):
 </ul>
 Thus, it is possible to act on multiple shapes at the same time.
 
-<p>
+<p id="JS9.NewShapeLayer">
 <font size="+1"><b><u>Create a new shape layer</u></b></font>
 <p>
 <code><font size="+1">lid = JS9.NewShapeLayer(layer, opts)</font></code>
@@ -2559,7 +2608,7 @@ generated tooltip will display current image id in bold, followed by
 that object's x,y pixel position, followed by a user <b>tag</b>
 property passed in the <b>data</b> object when the shape was added.
 
-<p>
+<p id="JS9.ShowShapeLayer">
 <font size="+1"><b><u>Show or hide the specified shape layer</u></b></font>
 <p>
 <code><font size="+1">JS9.ShowShapeLayer(layer, mode)</font></code>
@@ -2573,7 +2622,7 @@ Shape layers can be hidden from display. This could be useful, for
 example, if you have several catalogs loaded into a display and
 want to view one at a time.
 
-<p>
+<p id="JS9.ActiveShapeLayer">
 <font size="+1"><b><u>Make the specified shape layer the active layer</u></b></font>
 <p>
 <code><font size="+1">JS9.ActiveShapeLayer(layer)</font></code>
@@ -2605,7 +2654,7 @@ This routine forms the basis for the <b>Shape Layer</b> plugin, which
 provides a graphical way to make a layer active (by moving it to the
 top of the layer stack).
 
-<p>
+<p id="JS9.AddShapes">
 <font size="+1"><b><u>Add one or more shapes to the specified layer</u></b></font>
 <p>
 <code><font size="+1">JS9.AddShapes(layer, sarr, opts)</font></code>
@@ -2644,7 +2693,8 @@ more properties, of which the most important are:
 <li><b>text</b>: text associated with text shape
 <li><b>data</b>: this property can be an object, string, number,
 etc. and will be carried along with the shape, and returned as a
-property by the <b>JS9.GetShapes()</b> call.
+property by the
+<a href="#JS9.GetShapes"><b>JS9.GetShapes()</b></a> call.
 </ul>
 Other available properties include:
 <ul>
@@ -2667,7 +2717,7 @@ Deprecated properties:
 <li><b>fixinplace</b>: opposite of changeable
 </ul>
 
-<p>
+<p id="JS9.RemoveShapes">
 <font size="+1"><b><u>Remove one or more shapes from the specified shape layer</u></b></font>
 <p>
 <code><font size="+1">JS9.RemoveShapes(layer, shapes)</font></code>
@@ -2678,7 +2728,7 @@ where:
 <li><b>shapes</b>: which shapes to remove
 </ul>
 
-<p>
+<p id="JS9.GetShapes">
 <font size="+1"><b><u>Get information about one or more shapes in the specified shape layer</u></b></font>
 <p>
 <code><font size="+1">JS9.GetShapes(layer, shapes)</font></code>
@@ -2711,7 +2761,7 @@ Each returned shape object contains the following properties:
 <li><b>data</b>: data property passed in options object when this shape was created.
 </ul>
 
-<p>
+<p id="JS9.ChangeShapes">
 <font size="+1"><b><u>Change one or more shapes in the specified layer</u></b></font>
 <p>
 <code><font size="+1">JS9.ChangeShapes(layer, shapes, opts)</font></code>
@@ -2723,10 +2773,12 @@ where:
 <li><b>opts</b>: object containing options to change in each shape
 </ul>
 Change one or more shapes. The opts object can contain the parameters 
-described in the <b>JS9.AddShapes()</b> section. However, you cannot (yet)
+described in the
+<a href="#JS9.AddShapes"><b>JS9.AddShapes()</b></a>
+section. However, you cannot (yet)
 change the shape itself (e.g. from "box" to "circle").
 
-<p>
+<p id="JS9.LoadCatalog">
 <font size="+1"><b><u>Load an astronomical catalog</u></b></font>
 <p>
 <code><font size="+1">JS9.LoadCatalog(layer, table, opts)</font></code>
@@ -2864,14 +2916,15 @@ save in the data object for use in the tooltip string, e.g.:
 </pre>
 in the above VizieR example. Caveat: any "." (dot) in any catalog property
 name will be converted to "_" (underscore) automatically. For a more detailed
-discussion of tooltips, please see <b>JS9.NewShapeLayer()</b>.
+discussion of tooltips, please see
+<a href="#JS9.NewShapeLayer"><b>JS9.NewShapeLayer()</b></a>.
 
 <p>
 When catalog layer has been created, you can use the <b>Shape Layers</b>
 plugin to toggle its visibility and also to change its position in the layer
 stack.
 
-<p>
+<p id="JS9.SaveCatalog">
 <font size="+1"><b><u>Save an astronomical catalog to a file</u></b></font>
 <p>
 <code><font size="+1">JS9.SaveCatalog(filename, which)</font></code>
@@ -2985,7 +3038,7 @@ new action.
 </font></b></center>
 <p>
 
-<p>
+<p id="JS9.RunAnalysis">
 <font size="+1"><b><u>Run a simple server-side analysis task</u></b></font>
 <p>
 <code><font size="+1">JS9.RunAnalysis(name, parr, func)</font></code>
@@ -3047,7 +3100,7 @@ property <b>JS9.globalOpts.analysisDiv</b> to the id of your new
 target div. The div must have CSS height and width properties if you
 are going to plot results.
 
-<p>
+<p id="JS9.SubmitAnalysis">
 <font size="+1"><b><u>Run a server-side analysis task, utilizing
 parameters in a form</u></b></font>
 <p>
@@ -3067,7 +3120,9 @@ that these values can be integrated into the analysis command line.
 See js9analysis.html for a simple example.
 <p>
 The <b>func</b> callback and global options are the same as
-for <b>JS9.RunAnalysis()</b> above.
+for
+<a href="#JS9.RunAnalysis"><b>JS9.RunAnalysis()</b></a>
+above.
 
 <p><hr><p>
 <center><b><font size="+1">
@@ -3075,7 +3130,7 @@ for <b>JS9.RunAnalysis()</b> above.
 </font></b></center>
 <p>
 
-<p>
+<p id="JS9.LookupDisplay">
 <font size="+1"><b><u>Lookup a JS9 display</u></b></font>
 <p>
 <code><font size="+1">dobj = JS9.LookupDisplay(dname, mustExist)</font></code>
@@ -3097,7 +3152,9 @@ If <b>dname</b> is specified but does not exist, an error is thrown unless
 the <b>mustExist</b> parameter is explicitly set to false (i.e., the default
 is that the id must exist).
 
+<p id="JS9.ResizeDisplay">
 <font size="+1"><b><u>Resize the JS9 Display</u></b></font>
+</p>
 <p>
 <code><font size="+1">JS9.ResizeDisplay(dname, width, height, opts)</font></code>
 <p>
@@ -3145,7 +3202,7 @@ or:
     JS9.ResizeDisplay(350, 400, {display: "myJS9"});
 </pre>
 
-<p>
+<p id="JS9.MoveToDisplay">
 <font size="+1"><b><u>Move an image to a new JS9 display</u></b></font>
 <p>
 <code><font size="+1">JS9.MoveToDisplay(dname)</font></code>
@@ -3163,10 +3220,12 @@ will move the current image displayed in the "JS9" display window to
 the "myJS9" window. 
 <p>
 Note that the new JS9 display must already exist. New displays can be
-created with the <b>JS9.LoadWindow()</b> public access routine or
+created with the
+<a href="#JS9.LoadWindow"><b>JS9.LoadWindow()</b></a>
+public access routine or
 the <b>File:new JS9 light window</b> menu option.
 
-<p>
+<p id="JS9.GatherDisplay">
 <font size="+1"><b><u>Gather other images to this JS9 Display</u></b></font>
 <p>
 <code><font size="+1">JS9.GatherDisplay(dname)</font></code>
@@ -3186,7 +3245,7 @@ or:
     JS9.GatherDisplay({display: "myJS9"});
 </pre>
 
-<p>
+<p id="JS9.SeparateDisplay">
 <font size="+1"><b><u>Separate images in this JS9 Display into new displays</u></b></font>
 <p>
 <code><font size="+1">JS9.SeparateDisplay(dname)</font></code>
@@ -3206,7 +3265,7 @@ or:
     JS9.SeparateDisplay({display: "myJS9"});
 </pre>
 
-<p>
+<p id="JS9.CenterDisplay">
 <font size="+1"><b><u>Scroll the JS9 display to the center of the viewport</u></b></font>
 <p>
 <code><font size="+1">JS9.CenterDisplay(dname)</font></code>
@@ -3227,7 +3286,7 @@ or:
 </font></b></center>
 <p>
 
-<p>
+<p id="JS9.Print">
 <font size="+1"><b><u>Print an image</u></b></font>
 <p>
 <code><font size="+1">JS9.Print(opts)</font></code>
@@ -3248,7 +3307,7 @@ By default, if a colorbar is active on the page, it will be placed
 beneath the image. You can pass the <b>colorbar: false</b> option
 in the <b>opts</b> object to avoid printing the active colorbar.
 
-<p>
+<p id="JS9.SaveFITS">
 <font size="+1"><b><u>Save image as a FITS file</u></b></font>
 <p>
 <code><font size="+1">JS9.SaveFITS(filename)</font></code>
@@ -3264,7 +3323,7 @@ specified, the file will be saved as "js9.fits".
 Don't forget that the file is saved by the browser, in whatever location
 you have set up for downloads.
 
-<p>
+<p id="JS9.SavePNG">
 <font size="+1"><b><u>Save image as a PNG file</u></b></font>
 <p>
 <code><font size="+1">JS9.SavePNG(filename)</font></code>
@@ -3281,7 +3340,7 @@ along with the graphical overlays (regions, etc.).
 Don't forget that the file is saved by the browser, in whatever location
 you have set up for downloads.
 
-<p>
+<p id="JS9.SaveJPEG">
 <font size="+1"><b><u>Save image as a JPEG file</u></b></font>
 <p>
 <code><font size="+1">JS9.SaveJPEG(filename, quality)</font></code>
@@ -3301,7 +3360,7 @@ least), this default values is 0.95 (I think).
 Don't forget that the file is saved by the browser, in whatever location
 you have set up for downloads.
 
-<p>
+<p id="JS9.GetFITSHeader">
 <font size="+1"><b><u>Get FITS header as a string</u></b></font>
 <p>
 <code><font size="+1">JS9.GetFITSHeader(nlflag)</font></code>
@@ -3314,14 +3373,16 @@ Return the FITS header as a string. By default, the returned string contains
 the 80-character FITS cards all concatenated together. If <b>nlflag</b>
 is <b>true</b>, each card will have a new-line appended.
 <p>
-Note that the <b>JS9.GetImageData()</b> routine also returns the
+Note that the
+<a href="#JS9.GetImageData"><b>JS9.GetImageData()</b></a>
+routine also returns the
 FITS header, but as an object whose properties contain the header
 values. For example, obj.SIMPLE will usually have a value of true,
 obj.BITPIX will have contain the bits/pixel, etc. This object is more
 useful for programming tasks, but does not contain the FITS comments
 associated with each header card.
 
-<p>
+<p id="JS9.DisplayHelp">
 <font size="+1"><b><u>Display help in a light window</u></b></font>
 <p>
 <code><font size="+1">JS9.DisplayHelp(name)</font></code>
@@ -3334,7 +3395,7 @@ The help file names are the property names in JS9.helpOpts (e.g., "user" for
 the user page, "install" for the install page, etc.). Alternatively, you can
 specify an arbitrary URL to display (just because).
 
-<p>
+<p id="JS9.DisplayPlugin">
 <font size="+1"><b><u>Display plugin in a light window</u></b></font>
 <p>
 <code><font size="+1">JS9.DisplayPlugin(name)</font></code>
@@ -3373,7 +3434,7 @@ nothing if the plugin is explicitly defined on the web page.
 This routine is useful if you are building a web interface that
 supports the JS9 menu functions.
 
-<p>
+<p id="JS9.LightWindow">
 <font size="+1"><b><u>Display content in a light window</u></b></font>
 <p>
 <code><font size="+1">JS9.LightWindow(id, type, content, title, opts)</font></code>
@@ -3422,7 +3483,7 @@ to <b>JS9.LightWindow()</b> or make up your own configuration string.
 As an extension to the Dynamic Drive light window support, JS9 adds the ability
 to double-click the title bar in order to close the window.
 
-<p>
+<p id="JS9.OpenFileMenu">
 <font size="+1"><b><u>Use the file dialog box to load a FITS file</u></b></font>
 <p>
 <code><font size="+1">JS9.OpenFileMenu()</font></code>
@@ -3433,7 +3494,7 @@ FITS file is selected, if will be loaded into the JS9 display.
 This routine is useful if you are building a web interface that
 supports the JS9 menu functions.
 
-<p>
+<p id="JS9.OpenRegionsMenu">
 <font size="+1"><b><u>Use the file dialog box to load a region file</u></b></font>
 <p>
 <code><font size="+1">JS9.OpenRegionsMenu()</font></code>
@@ -3444,7 +3505,7 @@ selected, if will be loaded into the JS9 display.
 This routine is useful if you are building a web interface that
 supports the JS9 menu functions.
 
-<p>
+<p id="JS9.OpenColormapMenu">
 <font size="+1"><b><u>Use the file dialog box to load a colormap file</u></b></font>
 <p>
 <code><font size="+1">JS9.OpenColormapMenu()</font></code>
@@ -3460,10 +3521,11 @@ display. The colormap file can take one of two forms (without the comments):
     {"name":"purple","vertices":[[[0,0],[1,1]],[[0,0],[0,0]],[[0,0],[1,1]]]}
 </pre>
 This routine is useful if you are building a web interface that
-supports the JS9 menu functions. See <b>JS9.AddColormap()</b> for more
+supports the JS9 menu functions. See
+<a href="#JS9.AddColormap"><b>JS9.AddColormap()</b></a> for more
 information about colormap formats.
 
-<p>
+<p id="JS9.GetToolbar">
 <font size="+1"><b><u>Get toolbar values from the Toolbar plugin</u></b></font>
 <p>
 <code><font size="+1">val = JS9.GetToolbar(type)</font></code>
@@ -3481,7 +3543,7 @@ plugin. If the first argument is "showTooltips", the returned value specifies
 whether tooltips are currently displayed. Otherwise an array of tool objects is
 returned, one for each of the defined tools in the toolbar.
 
-<p>
+<p id="JS9.SetToolbar">
 <font size="+1"><b><u>Set toolbar values for the Toolbar plugin</u></b></font>
 <p>
 <code><font size="+1">JS9.SetToolbar(arg1, arg2)</font></code>
@@ -3575,7 +3637,7 @@ active toolbars by calling:
     JS9.SetToolbar("init");
 </pre>
 
-<p>
+<p id="JS9.InstalLDir">
 <font size="+1"><b><u>Get location of JS9 installation directory</u></b></font>
 <p>
 <code><font size="+1">rpath = JS9.InstallDir(file)</font></code>
@@ -3593,7 +3655,7 @@ sub-directory. The web page loading the plugin has an arbitrary
 location relative to the JS9 install directory, so this routine
 returns a relative path to the js9 install directory.
 
-<p>
+<p id="JS9.Send">
 <font size="+1"><b><u>Send a message to a back-end server</u></b></font>
 <p>
 <code><font size="+1">JS9.Send(msg, obj, cb)</font></code>
@@ -3618,15 +3680,18 @@ write your own socket.io-based server, you might want to add
 project-specific messages to your implementation. For example, a
 Perl-based or Python-based server might add its own special messages
 that execute Perl or Python commands within the server in response to
-JS9 messages. In this case, you can use <b>JS9.Send()</b> to send a
-message to these message handlers.
+JS9 messages. In this case, you can use
+<a href="#JS9.Send"><b>JS9.Send()</b></a>
+to send a message to these message handlers.
 <p>
 The <b>msg</b> name is the name of the message, as defined by the
 server. By convention, an object is usually passed to the
 message handler. JS9 will add a <b>dataPath</b> property to this
 object to indicate the current list of directories in which to
 search for data. All other properties are specific to the message being handled.
-You can pass a null instead of an object and <b>JS9.Send()</b> will generate
+You can pass a null instead of an object and
+<a href="#JS9.Send"><b>JS9.Send()</b></a>
+will generate
 a temporary object to hold the dataPath.
 <p>
 The <b>cb</b> function will be called if the message sends an
@@ -3641,7 +3706,7 @@ list of available analysis tasks and then display this list using the call:
 The "getAnalysis" message passes no parameters to the server. The
 server returns a list of available analysis tasks in json format.
 
-<p>
+<p id="JS9.AddDivs">
 <font size="+1"><b><u>Add a JS9 display div and/or associated plugins</u></b></font>
 <p>
 <code><font size="+1">JS9.AddDivs(id1, id2, ...)</font></code>
@@ -3669,10 +3734,12 @@ page and load an image into that display:
     // just a standard load to that display
     JS9.Load("foo.fits", {scale: "log"}, {display: "myJS9"});
 </pre>
-See also <b>JS9.LoadWindow()</b> for a nice way to load images into a
+See also
+<a href="#JS9.LoadWindow"><b>JS9.LoadWindow()</b></a>
+for a nice way to load images into a
 light-weight or completely new window.
 
-<p>
+<p id="JS9.InstantiatePlugins">
 <font size="+1"><b><u>Instantiate plugins on this web page</u></b></font>
 <p>
 <code><font size="+1">JS9.InstantiatePlugins()</font></code>
@@ -3681,8 +3748,9 @@ Normally, JS9 will instantiate all of its plugins automatically once the page
 is loaded and ready: internally, jQuery $(document).ready() calls JS9.init().
 However, module loaders such as <a href="http://requirejs.org">Require.js</a>
 can load scripts asynchronously and cause jQuery $(document).ready() to fire
-before all JS9 scripts are available. The <b>RegisterPlugin()</b> routine
-should deal properly with this situation. But just in case ...
+before all JS9 scripts are available. The
+<a href="#JS9.RegisterPlugin"><b>RegisterPlugin()</b></a>
+routine should deal properly with this situation. But just in case ...
 the <b>JS9.InstantiatePlugins()</b> will perform the plugin instantiation 
 explicitly.
 <p>
@@ -3698,7 +3766,7 @@ NB: The routines in this section are prototypes and therefore are
 subject to change. Feel free to contact us to discuss your needs so
 that we can gain a better understanding of what is required in these cases.
 
-<p>
+<p id="JS9.LoadAuxFile">
 <font size="+1"><b><u>Load an auxiliary file</u></b></font>
 <p>
 <code><font size="+1">JS9.LoadAuxFile(name, func)</font></code>
@@ -3797,7 +3865,10 @@ forced to make an incompatible change to the API, it will be documented here.
 20151218: OpenFileMenu and OpenRegionsMenu don't require a display argument
 </u></b></font>
 <p>
-The routines <b>OpenFileMenu()</b> and <b>OpenRegionsMenu()</b>
+The routines
+<a href="#JS9.OpenFileMenu"><b>OpenFileMenu()</b></a>
+and
+<a href="#JS9.OpenRegionsMenu"><b>OpenRegionsMenu()</b></a>
 required a display argument, instead of utilizing the standard
 optional display object. This mistake has been corrected, with the
 result that both routines now target the default display, as expected,
@@ -3807,7 +3878,9 @@ if no display is passed.
 20141117: The Set routines now return "OK" instead of true on success
 </u></b></font>
 <p>
-The public Set routines (<b>SetZoom()</b>, <b>SetColormap()</b>, etc)
+The public Set routines
+(<a href="#JS9.SetZoom"><b>SetZoom()</b></a>,
+<a href="#JS9.SetColormap"><b>SetColormap()</b></a>, etc)
 were returning a boolean true when successful. This has been changed
 to "OK", to make it clear that the return value is a status value,
 not a boolean data value.
@@ -3817,8 +3890,10 @@ not a boolean data value.
 </u></b></font>
 <p>
 Due to an oversight, the signature of the callback function supplied to
-<b>RunAnalysis()</b> (and its derivative function, 
-<b>SubmitAnalysis()</b>) was missing the errcode argument. 
+<a href="#JS9.RunAnalysis"><b>RunAnalysis()</b></a>
+(and its derivative function, 
+<a href="#JS9.SubmitAnalysis"><b>SubmitAnalysis()</b></a>)
+was missing the errcode argument. 
 To correct this mistake, the signature was changed from:
 <pre>
     func(stdout, stderr, aobj)
@@ -3831,7 +3906,7 @@ See js9onchange.html for an example of using this callback function.
 
 <p><hr><p>
 
-<h5>Last updated: January 29, 2018</h5>
+<h5>Last updated: February 12, 2018</h5>
 </div>
 
 </body>

--- a/help/publicapi.html
+++ b/help/publicapi.html
@@ -19,6 +19,10 @@
     font-size: larger;
     text-decoration: underline;
   }
+
+  code.api {
+    font-size: larger;
+  }
 </style>
 </head>
 <body>
@@ -114,7 +118,7 @@ Choose from the following sections:
 
 <h5 id="JS9.Load">Load an image into JS9</h5>
 <p> 
-<code><font size="+1">JS9.Load(url, opts)</font></code>
+<code class="api">JS9.Load(url, opts)</code>
 <p>
 where:
 <ul>
@@ -165,7 +169,7 @@ how to use this routine.
 
 <h5 id="JS9.LoadWindow">Load an image into a light window or a new (separate) window</h5>
 <p>
-<code><font size="+1">JS9.LoadWindow(url, opts, type, html, winopts)</font></code>
+<code class="api">JS9.LoadWindow(url, opts, type, html, winopts)</code>
 <p>
 where:
 <ul>
@@ -215,7 +219,7 @@ See js9create.html for examples of how to use this routine.
 
 <h5 id="JS9.LoadProxy">Load an image URL into JS9 using a proxy server</h5>
 <p> 
-<code><font size="+1">JS9.LoadProxy(url, opts)</font></code>
+<code class="api">JS9.LoadProxy(url, opts)</code>
 <p>
 where:
 <ul>
@@ -289,7 +293,7 @@ can be used to view images from arbitrary URLs.
 
 <h5 id="JS9.Preload">Load one or more images when the web page is ready</h5>
 <p>
-<code><font size="+1">JS9.Preload(url1, opts1, url2, opts2, ... url2, optsn)</font></code>
+<code class="api">JS9.Preload(url1, opts1, url2, opts2, ... url2, optsn)</code>
 <p>
 where:
 <ul>
@@ -308,7 +312,7 @@ generally is called using an onload routine tied to the web page body.
   
 <h5 id="JS9.GetLoadStatus">Get Load Status</h5>
 <p> 
-<code><font size="+1">status = JS9.GetLoadStatus(id)</font></code>
+<code class="api">status = JS9.GetLoadStatus(id)</code>
 <p>
 where:
 <ul>
@@ -344,7 +348,7 @@ Thus, to check for image load, one can do this in python:
 
 <h5 id="JS9.GetImage">Get image handle for the current image</h5>
 <p>
-<code><font size="+1">im = JS9.GetImage()</font></code>
+<code class="api">im = JS9.GetImage()</code>
 <p>
 returns:
 <ul>
@@ -359,7 +363,7 @@ determine the current image for each call.
 
 <h5 id="JS9.LookupImage">Lookup an image by id</h5>
 <p>
-<code><font size="+1">im = JS9.LookupImage(id)</font></code>
+<code class="api">im = JS9.LookupImage(id)</code>
 <p>
 where:
 <ul>
@@ -393,7 +397,7 @@ you can close foo2.fits this way:
 
 <h5 id="JS9.GetImageData">Get image data and auxiliary info for the specified image</h5>
 <p>
-<code><font size="+1">imdata = JS9.GetImageData(dflag)</font></code>
+<code class="api">imdata = JS9.GetImageData(dflag)</code>
 <p>
 where:
 <ul>
@@ -475,7 +479,7 @@ by convention, x.0, y.0 is the middle of the pixel.
 
 <h5 id="JS9.GetDisplayData">Get image data for all images loaded into the specified display</h5>
 <p>
-<code><font size="+1">imarr = JS9.GetDisplayData()</font></code>
+<code class="api">imarr = JS9.GetDisplayData()</code>
 <p>
 returns:
 <ul>
@@ -491,7 +495,7 @@ with the display, not just the current image.
 
 <h5 id="JS9.DisplayImage">Display an image</h5>
 <p>
-<code><font size="+1">JS9.DisplayImage(step)</font></code>
+<code class="api">JS9.DisplayImage(step)</code>
 <p>
 where:
 <ul>
@@ -507,7 +511,7 @@ explicitly changed parameter(s) used in a prior step.
 
 <h5 id="JS9.RefreshImage">Re-read the image data and re-display</h5>
 <p>
-<code><font size="+1">JS9.RefreshImage(input, func)</font></code>
+<code class="api">JS9.RefreshImage(input, func)</code>
 <p>
 where:
 <ul>
@@ -575,7 +579,7 @@ display.
 
 <h5 id="JS9.DisplaySection">Extract and display a section of a FITS file</h5>
 <p>
-<code><font size="+1">JS9.DisplaySection(opts)</font></code>
+<code class="api">JS9.DisplaySection(opts)</code>
 <p>
 where:
 <ul>
@@ -667,7 +671,7 @@ conventions, which are documented
 
 <h5 id="JS9.DisplayExtension">Display an extension from a multi-extension FITS file</h5>
 <p>
-<code><font size="+1">JS9.DisplayExtension(extid, opts)</font></code>
+<code class="api">JS9.DisplayExtension(extid, opts)</code>
 <p>
 where:
 <ul>
@@ -681,7 +685,7 @@ for information about HDUs and multi-extension FITS).
 
 <h5 id="JS9.DisplaySlice">Display a slice of a FITS data cube</h5>
 <p>
-<code><font size="+1">JS9.DisplaySlice(slice, opts)</font></code>
+<code class="api">JS9.DisplaySlice(slice, opts)</code>
 <p>
 where:
 <ul>
@@ -726,7 +730,7 @@ appended.
 
 <h5 id="JS9.BlendImage">Blend the image in an image stack using W3C composite/blend modes</h5>
 <p>
-<code><font size="+1">JS9.BlendImage(blendMode, opacity)</font></code>
+<code class="api">JS9.BlendImage(blendMode, opacity)</code>
 <p>
 Calling sequences:
 <pre>
@@ -832,7 +836,7 @@ Other actions will be added as we gain experience with blending operations
 
 <h5 id="JS9.BlendDisplay">Set the global image blend more for the specified display</h5>
 <p>
-<code><font size="+1">mode = JS9.BlendDisplay(true|false)</font></code>
+<code class="api">mode = JS9.BlendDisplay(true|false)</code>
 <p>
 returns:
 <ul>
@@ -843,7 +847,7 @@ display. If no argument is specified, it returns the current blend mode.
 
 <h5 id="JS9.CloseImage">Clear the image from the display and mark resources for release</h5>
 <p>
-<code><font size="+1">JS9.CloseImage()</font></code>
+<code class="api">JS9.CloseImage()</code>
 <p>
 Each loaded image claims a non-trivial amount of memory from a finite
 amount of browser heap space. For example, the default 32-bit version
@@ -860,7 +864,7 @@ go away ...
 
 <h5 id="JS9.GetColormap">Get the image colormap</h5>
 <p>
-<code><font size="+1">cmap = JS9.GetColormap()</font></code>
+<code class="api">cmap = JS9.GetColormap()</code>
 <p>
 returns:
 <ul>
@@ -875,7 +879,7 @@ The returned cmap object will contain the following properties:
 
 <h5 id="JS9.SetColormap">Set the image colormap</h5>
 <p>
-<code><font size="+1">JS9.SetColormap(colormap, [contrast, bias])</font></code>
+<code class="api">JS9.SetColormap(colormap, [contrast, bias])</code>
 <p>
 where:
 <ul>
@@ -889,7 +893,7 @@ arguments.
 
 <h5 id="JS9.SaveColormap">Save current colormap definition</h5>
 <p>
-<code><font size="+1">JS9.SaveColormap(filename)</font></code>
+<code class="api">JS9.SaveColormap(filename)</code>
 <p>
 where:
 <ul>
@@ -907,7 +911,7 @@ you have set up for downloads.
 
 <h5 id="JS9.AddColormap">Add a colormap to JS9</h5>
 <p>
-<code><font size="+1">JS9.AddColormap(name, aa|rr,gg,bb|obj|json)</font></code>
+<code class="api">JS9.AddColormap(name, aa|rr,gg,bb|obj|json)</code>
 <p>
 where:
 <ul>
@@ -984,7 +988,7 @@ all JS9 displays on the given page.
 
 <h5 id="JS9.LoadColormap">Load a colormap file into JS9</h5>
 <p>
-<code><font size="+1">JS9.LoadColormap(filename)</font></code>
+<code class="api">JS9.LoadColormap(filename)</code>
 <p>
 where:
 <ul>
@@ -1055,7 +1059,7 @@ the new colormap will be available in all displays.
 
 <h5 id="JS9.GetRGBMode">Get RGB Mode</h5>
 <p>
-<code><font size="+1">JS9.GetRGBMode()</font></code>
+<code class="api">JS9.GetRGBMode()</code>
 <p>
 returns:
 <ul>
@@ -1071,7 +1075,7 @@ The returned object will contain the following properties:
 
 <h5 id="JS9.SetRGBMode">Set RGB Mode</h5>
 <p>
-<code><font size="+1">JS9.SetRGBMode(mode, [imobj])</font></code>
+<code class="api">JS9.SetRGBMode(mode, [imobj])</code>
 <p>
 where:
 <ul>
@@ -1104,7 +1108,7 @@ If no arguments are specified, the current RGB mode is toggled;
 
 <h5 id="JS9.GetScale">Get the image scale</h5>
 <p>
-<code><font size="+1">scale = JS9.GetScale()</font></code>
+<code class="api">scale = JS9.GetScale()</code>
 <p>
 returns:
 <ul>
@@ -1119,7 +1123,7 @@ The returned scale object will contain the following properties:
 
 <h5 id="JS9.SetScale">Set the image scale</h5>
 <p>
-<code><font size="+1">JS9.SetScale(scale, smin, smax)</font></code>
+<code class="api">JS9.SetScale(scale, smin, smax)</code>
 <p>
 where:
 <ul>
@@ -1133,7 +1137,7 @@ or "zmax" is specified, any supplied smin and smax values are ignored.)
 
 <h5 id="JS9.GetZoom">Get the image zoom factor</h5>
 <p>
-<code><font size="+1">zoom = JS9.GetZoom()</font></code>
+<code class="api">zoom = JS9.GetZoom()</code>
 <p>
 returns:
 <ul>
@@ -1143,7 +1147,7 @@ Get the zoom factor.
 
 <h5 id="JS9.SetZoom">Set the image zoom factor</h5>
 <p>
-<code><font size="+1">JS9.SetZoom(zoom)</font></code>
+<code class="api">JS9.SetZoom(zoom)</code>
 <p>
 where:
 <ul>
@@ -1160,7 +1164,7 @@ The zoom directives are:
 
 <h5 id="JS9.GetPan">Get the image pan position</h5>
 <p>
-<code><font size="+1">ipos = JS9.GetPan()</font></code>
+<code class="api">ipos = JS9.GetPan()</code>
 <p>
 returns:
 <ul>
@@ -1174,7 +1178,7 @@ The returned ipos object will contain the following properties:
 
 <h5 id="JS9.SetPan">Set the image pan position</h5>
 <p>
-<code><font size="+1">JS9.SetPan(x, y)</font></code>
+<code class="api">JS9.SetPan(x, y)</code>
 <p>
 where:
 <ul>
@@ -1193,7 +1197,7 @@ to convert between image and WCS coordinates.
 
 <h5 id="JS9.GetParam">Get an image parameter value</h5>
 <p>
-<code><font size="+1">val = JS9.GetParam(param)</font></code>
+<code class="api">val = JS9.GetParam(param)</code>
 <p>
 where:
 <ul>
@@ -1214,7 +1218,7 @@ section.
 
 <h5 id="JS9.SetParam">Set an image parameter value</h5>
 <p>
-<code><font size="+1">ovalue = JS9.SetParam(param, value)</font></code>
+<code class="api">ovalue = JS9.SetParam(param, value)</code>
 <p>
 where:
 <ul>
@@ -1256,7 +1260,7 @@ is complete.
 
 <h5 id="JS9.EventToDisplayPos">Get the display coordinates from an event</h5>
 <p>
-<code><font size="+1">dpos = JS9.EventToDisplayPos(evt)</font></code>
+<code class="api">dpos = JS9.EventToDisplayPos(evt)</code>
 <p>
 where:
 <ul>
@@ -1273,7 +1277,7 @@ image position (see below).
 
 <h5 id="JS9.DIsplayToImagePos">Get the image coordinates from the display coordinates</h5>
 <p>
-<code><font size="+1">ipos = JS9.DisplayToImagePos(dpos)</font></code>
+<code class="api">ipos = JS9.DisplayToImagePos(dpos)</code>
 <p>
 where:
 <ul>
@@ -1290,7 +1294,7 @@ display coordinate are 0-indexed.
 
 <h5 id="JS9.ImageToDisplayPos">Get the display coordinates from the image coordinates</h5>
 <p>
-<code><font size="+1">dpos = JS9.ImageToDisplayPos(ipos)</font></code>
+<code class="api">dpos = JS9.ImageToDisplayPos(ipos)</code>
 <p>
 where:
 <ul>
@@ -1308,7 +1312,7 @@ display coordinate are 0-indexed.
 
 <h5 id="JS9.LogicalToImagePos">Get the image coordinates from the logical coordinates</h5>
 <p>
-<code><font size="+1">ipos = JS9.LogicalToImagePos(lpos, lcs)</font></code>
+<code class="api">ipos = JS9.LogicalToImagePos(lpos, lcs)</code>
 <p>
 where:
 <ul>
@@ -1332,7 +1336,7 @@ coordinate system (assuming the appropriate keywords have been defined).
 
 <h5 id="JS9.ImageToLogicalPos">Get the logical coordinates from the image coordinates</h5>
 <p>
-<code><font size="+1">lpos = JS9.ImageToLogicalPos(ipos, lcs)</font></code>
+<code class="api">lpos = JS9.ImageToLogicalPos(ipos, lcs)</code>
 <p>
 where:
 <ul>
@@ -1355,7 +1359,7 @@ coordinate system (assuming the appropriate keywords have been defined).
 
 <h5 id="JS9.GetValPos">Get value/position information</h5>
 <p>
-<code><font size="+1">valpos = JS9.GetValPos(ipos, display)</font></code>
+<code class="api">valpos = JS9.GetValPos(ipos, display)</code>
 <p>
 where:
 <ul>
@@ -1389,7 +1393,7 @@ or "physical") for the above px, py values
 
 <h5 id="JS9.SetValPos">Set the value/position display mode</h5>
 <p>
-<code><font size="+1">JS9.SetValPos(mode)</font></code>
+<code class="api">JS9.SetValPos(mode)</code>
 <p>
 where:
 <ul>
@@ -1399,7 +1403,7 @@ Set the display mode of the value/position display for the specified image.
 
 <h5 id="JS9.GetImageInherit">Get the image inherit mode</h5>
 <p>
-<code><font size="+1">inherit = JS9.GetImageInherit()</font></code>
+<code class="api">inherit = JS9.GetImageInherit()</code>
 <p>
 returns:
 <ul>
@@ -1412,7 +1416,7 @@ from the default JS9.imageOpts object.
 
 <h5 id="JS9.SetImageInherit">Set the image inherit mode</h5>
 <p>
-<code><font size="+1">JS9.SetImageInherit(mode)</font></code>
+<code class="api">JS9.SetImageInherit(mode)</code>
 <p>
 where:
 <ul>
@@ -1425,7 +1429,7 @@ from the default JS9.imageOpts object.
 
 <h5 id="JS9.GetWCS">Get information about the current WCS</h5>
 <p>
-<code><font size="+1">wcsobj = JS9.GetWCS()</font></code>
+<code class="api">wcsobj = JS9.GetWCS()</code>
 <p>
 returns:
 <ul>
@@ -1448,7 +1452,7 @@ with this WCS, if present
 
 <h5 id="JS9.SetWCS">Set the current WCS</h5>
 <p>
-<code><font size="+1">JS9.SetWCS(which)</font></code>
+<code class="api">JS9.SetWCS(which)</code>
 <p>
 where:
 <ul>
@@ -1472,7 +1476,7 @@ If no argument is supplied, the default WCS is set up.
 
 <h5 id="JS9.GetWCSUnits">Get the current WCS units</h5>
 <p>
-<code><font size="+1">unitsstr = JS9.GetWCSUnits()</font></code>
+<code class="api">unitsstr = JS9.GetWCSUnits()</code>
 <p>
 returns:
 <ul>
@@ -1482,7 +1486,7 @@ Get the current WCS units.
 
 <h5 id="JS9>SetWCSUnits">Set the current WCS units</h5>
 <p>
-<code><font size="+1">JS9.SetWCSUnits(unitsstr)</font></code>
+<code class="api">JS9.SetWCSUnits(unitsstr)</code>
 <p>
 where:
 <ul>
@@ -1492,7 +1496,7 @@ Set the current WCS units.
 
 <h5 id="JS9.GetWCSSys">Get the current World Coordinate System</h5>
 <p>
-<code><font size="+1">sysstr = JS9.GetWCSSys()</font></code>
+<code class="api">sysstr = JS9.GetWCSSys()</code>
 <p>
 returns:
 <ul>
@@ -1503,7 +1507,7 @@ Get current WCS system.
 
 <h5 id="JS9.SetWCSSys">Set the current World Coordinate System</h5>
 <p>
-<code><font size="+1">JS9.SetWCSSys(sysstr)</font></code>
+<code class="api">JS9.SetWCSSys(sysstr)</code>
 <p>
 where:
 <ul>
@@ -1519,7 +1523,7 @@ For optical images, image and physical coordinate usually are identical.
 
 <h5 id="JS9.PixToWCS">Convert image pixel position to WCS position</h5>
 <p>
-<code><font size="+1">wcsobj = JS9.PixToWCS(x, y)</font></code>
+<code class="api">wcsobj = JS9.PixToWCS(x, y)</code>
 <p>
 where:
 <ul>
@@ -1541,7 +1545,7 @@ The wcs object contains the following properties:
 
 <h5 id="JS9.WCSToPix">Convert WCS position to image pixel position</h5>
 <p>
-<code><font size="+1">pixobj = JS9.WCSToPix(ra, dec)</font></code>
+<code class="api">pixobj = JS9.WCSToPix(ra, dec)</code>
 <p>
 where:
 <ul>
@@ -1561,7 +1565,7 @@ The pixel object contains the following properties:
 
 <h5 id="JS9.DisplayMessage">Display a text message</h5>
 <p>
-<code><font size="+1">JS9.DisplayMessage(which, text)</font></code>
+<code class="api">JS9.DisplayMessage(which, text)</code>
 <p>
 where:
 <ul>
@@ -1574,7 +1578,7 @@ empty string will clear the previous message.
 
 <h5 id="JS9.RawDataLayer">Create or modify a raw data layer</h5>
 <p>
-<code><font size="+1">JS9.RawDataLayer(opts, func)</font></code>
+<code class="api">JS9.RawDataLayer(opts, func)</code>
 <p>
 where:
 <ul>
@@ -1688,7 +1692,7 @@ To get the currently displayed layer, call the routine with no arguments:
 
 <h5 id="JS9.GaussBlurData">Gaussian blur of raw data</h5>
 <p>
-<code><font size="+1">JS9.GaussBlurData(sigma, opts)</font></code>
+<code class="api">JS9.GaussBlurData(sigma, opts)</code>
 <p>
 where:
 <ul>
@@ -1704,7 +1708,7 @@ here</a>.
 
 <h5 id="JS9.ImarithData">Perform image arithmetic on raw data</h5>
 <p>
-<code><font size="+1">JS9.ImarithData(op, arg1, opts)</font></code>
+<code class="api">JS9.ImarithData(op, arg1, opts)</code>
 <p>
 where:
 <ul>
@@ -1765,7 +1769,7 @@ it is unclear how one lines up images of different dimensions.
 
 <h5 id="JS9.ShiftData">Shift raw data</h5>
 <p>
-<code><font size="+1">JS9.ShiftData(x, y, opts)</font></code>
+<code class="api">JS9.ShiftData(x, y, opts)</code>
 <p>
 where:
 <ul>
@@ -1782,7 +1786,7 @@ that are only slightly offset from one another.
 
 <h5 id="JS9.FilterRGBImage">Apply a filter to the RGB image</h5>
 <p>
-<code><font size="+1">JS9.FilterRGBImage(filter, args)</font></code>
+<code class="api">JS9.FilterRGBImage(filter, args)</code>
 <p>
 where:
 <ul>
@@ -1900,7 +1904,7 @@ With no arguments, the routine returns an array of available filters:
 
 <h5 id="JS9.ReprojectData">Reproject an image using a specified WCS</h5>
 <p>
-<code><font size="+1">JS9.ReprojectData(wcsim, opts)</font></code>
+<code class="api">JS9.ReprojectData(wcsim, opts)</code>
 <p>
 where:
 <ul>
@@ -1962,7 +1966,7 @@ memory are evolving rapidly.
 
 <h5 id="JS9.RotateData">Rotate an image around the  WCS CRPIX point</h5>
 <p>
-<code><font size="+1">JS9.RotateData(angle, opts)</font></code>
+<code class="api">JS9.RotateData(angle, opts)</code>
 <p>
 where:
 <ul>
@@ -1980,7 +1984,7 @@ routine. See <b>JS9.ReprojectData()</b> above for more information.
 
 <h5 id="JS9.SaveSession">Save an image session to a file</h5>
 <p>
-<code><font size="+1">JS9.SaveSession(session, opts)</font></code>
+<code class="api">JS9.SaveSession(session, opts)</code>
 <p>
 where:
 <ul>
@@ -2023,7 +2027,7 @@ re-loading the session.
 
 <h5 id="JS9.LoadSession">Load a previously saved image session from a file</h5>
 <p>
-<code><font size="+1">JS9.LoadSession(session)</font></code>
+<code class="api">JS9.LoadSession(session)</code>
 <p>
 where:
 <ul>
@@ -2084,7 +2088,7 @@ Thus, it is possible to act on multiple regions at the same time.
 
 <h5 id="JS9.AddRegions">Add one or more regions to the regions layer</h5>
 <p>
-<code><font size="+1">id = JS9.AddRegions(rarr, opts)</font></code>
+<code class="api">id = JS9.AddRegions(rarr, opts)</code>
 <p>
 where:
 <ul>
@@ -2197,7 +2201,7 @@ etc.
 
 <h5 id="JS9.GetRegions">Get information about one or more regions</h5>
 <p>
-<code><font size="+1">rarr = JS9.GetRegions(regions)</font></code>
+<code class="api">rarr = JS9.GetRegions(regions)</code>
 <p>
 where:
 <ul>
@@ -2266,7 +2270,7 @@ by convention, x.0, y.0 is the middle of the pixel.
 
 <h5 id="JS9.ChangeRegions">Change one or more regions</h5>
 <p>
-<code><font size="+1">JS9.ChangeRegions(regions, opts)</font></code>
+<code class="api">JS9.ChangeRegions(regions, opts)</code>
 <p>
 where:
 <ul>
@@ -2297,7 +2301,7 @@ for examples of how to use this routine.
 
 <h5 id="JS9.CopyRegions">Copy one or more regions to another image</h5>
 <p>
-<code><font size="+1">JS9.CopyRegions(to, regions)</font></code>
+<code class="api">JS9.CopyRegions(to, regions)</code>
 <p>
 where:
 <ul>
@@ -2322,7 +2326,7 @@ slashes.e.g. "/foo[1-4]/" will match "foo1", "foo2", "foo3", "foo4";
 
 <h5 id="JS9.RemoveRegions">Remove one or more regions from the region layer</h5>
 <p>
-<code><font size="+1">JS9.RemoveRegions(regions)</font></code>
+<code class="api">JS9.RemoveRegions(regions)</code>
 <p>
 where:
 <ul>
@@ -2343,7 +2347,7 @@ slashes.e.g. "/foo[1-4]/" will match "foo1", "foo2", "foo3", "foo4";
 
 <h5 id="JS9.SaveRegions">Save regions from the current image to a file</h5>
 <p>
-<code><font size="+1">JS9.SaveRegions(filename, which, layer)</font></code>
+<code class="api">JS9.SaveRegions(filename, which, layer)</code>
 <p>
 where:
 <ul>
@@ -2373,7 +2377,7 @@ will save the data in table format instead of as regions).
 
 <h5 id="JS9.ToggleRegionTags">Toggle region tags from the current image</h5>
 <p>
-<code><font size="+1">JS9.ToggleRegionTags(which, t1, t2)</font></code>
+<code class="api">JS9.ToggleRegionTags(which, t1, t2)</code>
 <p>
 where:
 <ul>
@@ -2398,7 +2402,7 @@ will toggle between <b>include</b> and <b>exclude</b>.
 
 <h5 id="JS9.LoadRegions">Load regions from a file into the current image</h5>
 <p>
-<code><font size="+1">JS9.LoadRegions(filename)</font></code>
+<code class="api">JS9.LoadRegions(filename)</code>
 <p>
 where:
 <ul>
@@ -2438,7 +2442,7 @@ Thus, it is possible to act on multiple shapes at the same time.
 
 <h5 id="JS9.NewShapeLayer">Create a new shape layer</h5>
 <p>
-<code><font size="+1">lid = JS9.NewShapeLayer(layer, opts)</font></code>
+<code class="api">lid = JS9.NewShapeLayer(layer, opts)</code>
 <p>
 where:
 <ul>
@@ -2551,7 +2555,7 @@ property passed in the <b>data</b> object when the shape was added.
 
 <h5 id="JS9.ShowShapeLayer">Show or hide the specified shape layer</h5>
 <p>
-<code><font size="+1">JS9.ShowShapeLayer(layer, mode)</font></code>
+<code class="api">JS9.ShowShapeLayer(layer, mode)</code>
 <p>
 where:
 <ul>
@@ -2564,7 +2568,7 @@ want to view one at a time.
 
 <h5 id="JS9.ActiveShapeLayer">Make the specified shape layer the active layer</h5>
 <p>
-<code><font size="+1">JS9.ActiveShapeLayer(layer)</font></code>
+<code class="api">JS9.ActiveShapeLayer(layer)</code>
 <p>
 where:
 <ul>
@@ -2595,7 +2599,7 @@ top of the layer stack).
 
 <h5 id="JS9.AddShapes">Add one or more shapes to the specified layer</h5>
 <p>
-<code><font size="+1">JS9.AddShapes(layer, sarr, opts)</font></code>
+<code class="api">JS9.AddShapes(layer, sarr, opts)</code>
 <p>
 where:
 <ul>
@@ -2657,7 +2661,7 @@ Deprecated properties:
 
 <h5 id="JS9.RemoveShapes">Remove one or more shapes from the specified shape layer</h5>
 <p>
-<code><font size="+1">JS9.RemoveShapes(layer, shapes)</font></code>
+<code class="api">JS9.RemoveShapes(layer, shapes)</code>
 <p>
 where:
 <ul>
@@ -2667,7 +2671,7 @@ where:
 
 <h5 id="JS9.GetShapes">Get information about one or more shapes in the specified shape layer</h5>
 <p>
-<code><font size="+1">JS9.GetShapes(layer, shapes)</font></code>
+<code class="api">JS9.GetShapes(layer, shapes)</code>
 <p>
 where:
 <ul>
@@ -2699,7 +2703,7 @@ Each returned shape object contains the following properties:
 
 <h5 id="JS9.ChangeShapes">Change one or more shapes in the specified layer</h5>
 <p>
-<code><font size="+1">JS9.ChangeShapes(layer, shapes, opts)</font></code>
+<code class="api">JS9.ChangeShapes(layer, shapes, opts)</code>
 <p>
 where:
 <ul>
@@ -2715,7 +2719,7 @@ change the shape itself (e.g. from "box" to "circle").
 
 <h5 id="JS9.LoadCatalog">Load an astronomical catalog</h5>
 <p>
-<code><font size="+1">JS9.LoadCatalog(layer, table, opts)</font></code>
+<code class="api">JS9.LoadCatalog(layer, table, opts)</code>
 <p>
 where:
 <ul>
@@ -2860,7 +2864,7 @@ stack.
 
 <h5 id="JS9.SaveCatalog">Save an astronomical catalog to a file</h5>
 <p>
-<code><font size="+1">JS9.SaveCatalog(filename, which)</font></code>
+<code class="api">JS9.SaveCatalog(filename, which)</code>
 <p>
 where:
 <ul>
@@ -2970,7 +2974,7 @@ new action.
 
 <h5 id="JS9.RunAnalysis">Run a simple server-side analysis task</h5>
 <p>
-<code><font size="+1">JS9.RunAnalysis(name, parr, func)</font></code>
+<code class="api">JS9.RunAnalysis(name, parr, func)</code>
 <p>
 where:
 <ul>
@@ -3032,7 +3036,7 @@ are going to plot results.
 <h5 id="JS9.SubmitAnalysis">Run a server-side analysis task, utilizing
 parameters in a form</h5>
 <p>
-<code><font size="+1">JS9.SubmitAnalysis(el, name, func)</font></code>
+<code class="api">JS9.SubmitAnalysis(el, name, func)</code>
 <p>
 where:
 <ul>
@@ -3058,7 +3062,7 @@ above.
 
 <h5 id="JS9.LookupDisplay">Lookup a JS9 display</h5>
 <p>
-<code><font size="+1">dobj = JS9.LookupDisplay(dname, mustExist)</font></code>
+<code class="api">dobj = JS9.LookupDisplay(dname, mustExist)</code>
 <p>
 where:
 <ul>
@@ -3080,7 +3084,7 @@ is that the id must exist).
 <h5 id="JS9.ResizeDisplay">Resize the JS9 Display</h5>
 </p>
 <p>
-<code><font size="+1">JS9.ResizeDisplay(dname, width, height, opts)</font></code>
+<code class="api">JS9.ResizeDisplay(dname, width, height, opts)</code>
 <p>
 where:
 <ul>
@@ -3128,7 +3132,7 @@ or:
 
 <h5 id="JS9.MoveToDisplay">Move an image to a new JS9 display</h5>
 <p>
-<code><font size="+1">JS9.MoveToDisplay(dname)</font></code>
+<code class="api">JS9.MoveToDisplay(dname)</code>
 <p>
 where:
 <ul>
@@ -3150,7 +3154,7 @@ the <b>File:new JS9 light window</b> menu option.
 
 <h5 id="JS9.GatherDisplay">Gather other images to this JS9 Display</h5>
 <p>
-<code><font size="+1">JS9.GatherDisplay(dname)</font></code>
+<code class="api">JS9.GatherDisplay(dname)</code>
 <p>
 where:
 <ul>
@@ -3169,7 +3173,7 @@ or:
 
 <h5 id="JS9.SeparateDisplay">Separate images in this JS9 Display into new displays</h5>
 <p>
-<code><font size="+1">JS9.SeparateDisplay(dname)</font></code>
+<code class="api">JS9.SeparateDisplay(dname)</code>
 <p>
 where:
 <ul>
@@ -3188,7 +3192,7 @@ or:
 
 <h5 id="JS9.CenterDisplay">Scroll the JS9 display to the center of the viewport</h5>
 <p>
-<code><font size="+1">JS9.CenterDisplay(dname)</font></code>
+<code class="api">JS9.CenterDisplay(dname)</code>
 <p>
 This routine scrolls this display to the center of the viewport.
 You can supply a display name or the display object:
@@ -3206,7 +3210,7 @@ or:
 
 <h5 id="JS9.Print">Print an image</h5>
 <p>
-<code><font size="+1">JS9.Print(opts)</font></code>
+<code class="api">JS9.Print(opts)</code>
 <p>
 where:
 <ul>
@@ -3226,7 +3230,7 @@ in the <b>opts</b> object to avoid printing the active colorbar.
 
 <h5 id="JS9.SaveFITS">Save image as a FITS file</h5>
 <p>
-<code><font size="+1">JS9.SaveFITS(filename)</font></code>
+<code class="api">JS9.SaveFITS(filename)</code>
 <p>
 where:
 <ul>
@@ -3241,7 +3245,7 @@ you have set up for downloads.
 
 <h5 id="JS9.SavePNG">Save image as a PNG file</h5>
 <p>
-<code><font size="+1">JS9.SavePNG(filename)</font></code>
+<code class="api">JS9.SavePNG(filename)</code>
 <p>
 where:
 <ul>
@@ -3257,7 +3261,7 @@ you have set up for downloads.
 
 <h5 id="JS9.SaveJPEG">Save image as a JPEG file</h5>
 <p>
-<code><font size="+1">JS9.SaveJPEG(filename, quality)</font></code>
+<code class="api">JS9.SaveJPEG(filename, quality)</code>
 <p>
 where:
 <ul>
@@ -3276,7 +3280,7 @@ you have set up for downloads.
 
 <h5 id="JS9.GetFITSHeader">Get FITS header as a string</h5>
 <p>
-<code><font size="+1">JS9.GetFITSHeader(nlflag)</font></code>
+<code class="api">JS9.GetFITSHeader(nlflag)</code>
 <p>
 where:
 <ul>
@@ -3297,7 +3301,7 @@ associated with each header card.
 
 <h5 id="JS9.DisplayHelp">Display help in a light window</h5>
 <p>
-<code><font size="+1">JS9.DisplayHelp(name)</font></code>
+<code class="api">JS9.DisplayHelp(name)</code>
 <p>
 where:
 <ul>
@@ -3309,7 +3313,7 @@ specify an arbitrary URL to display (just because).
 
 <h5 id="JS9.DisplayPlugin">Display plugin in a light window</h5>
 <p>
-<code><font size="+1">JS9.DisplayPlugin(name)</font></code>
+<code class="api">JS9.DisplayPlugin(name)</code>
 <p>
 where:
 <ul>
@@ -3347,7 +3351,7 @@ supports the JS9 menu functions.
 
 <h5 id="JS9.LightWindow">Display content in a light window</h5>
 <p>
-<code><font size="+1">JS9.LightWindow(id, type, content, title, opts)</font></code>
+<code class="api">JS9.LightWindow(id, type, content, title, opts)</code>
 <p>
 where:
 <ul>
@@ -3395,7 +3399,7 @@ to double-click the title bar in order to close the window.
 
 <h5 id="JS9.OpenFileMenu">Use the file dialog box to load a FITS file</h5>
 <p>
-<code><font size="+1">JS9.OpenFileMenu()</font></code>
+<code class="api">JS9.OpenFileMenu()</code>
 <p>
 Calling this routine brings up the browser's file dialog box. When a
 FITS file is selected, if will be loaded into the JS9 display.
@@ -3405,7 +3409,7 @@ supports the JS9 menu functions.
 
 <h5 id="JS9.OpenRegionsMenu">Use the file dialog box to load a region file</h5>
 <p>
-<code><font size="+1">JS9.OpenRegionsMenu()</font></code>
+<code class="api">JS9.OpenRegionsMenu()</code>
 <p>
 Calling this routine brings up the browser file menu. When a region file is
 selected, if will be loaded into the JS9 display.
@@ -3415,7 +3419,7 @@ supports the JS9 menu functions.
 
 <h5 id="JS9.OpenColormapMenu">Use the file dialog box to load a colormap file</h5>
 <p>
-<code><font size="+1">JS9.OpenColormapMenu()</font></code>
+<code class="api">JS9.OpenColormapMenu()</code>
 <p>
 Calling this routine brings up the browser file menu. When a
 json-format colormap file is selected, it will be loaded into the JS9
@@ -3434,7 +3438,7 @@ information about colormap formats.
 
 <h5 id="JS9.GetToolbar">Get toolbar values from the Toolbar plugin</h5>
 <p>
-<code><font size="+1">val = JS9.GetToolbar(type)</font></code>
+<code class="api">val = JS9.GetToolbar(type)</code>
 <p>
 where:
 <ul>
@@ -3451,7 +3455,7 @@ returned, one for each of the defined tools in the toolbar.
 
 <h5 id="JS9.SetToolbar">Set toolbar values for the Toolbar plugin</h5>
 <p>
-<code><font size="+1">JS9.SetToolbar(arg1, arg2)</font></code>
+<code class="api">JS9.SetToolbar(arg1, arg2)</code>
 <p>
 where:
 <ul>
@@ -3544,7 +3548,7 @@ active toolbars by calling:
 
 <h5 id="JS9.InstallDir">Get location of JS9 installation directory</h5>
 <p>
-<code><font size="+1">rpath = JS9.InstallDir(file)</font></code>
+<code class="api">rpath = JS9.InstallDir(file)</code>
 <p>
 where:
 <ul>
@@ -3561,7 +3565,7 @@ returns a relative path to the js9 install directory.
 
 <h5 id="JS9.Send">Send a message to a back-end server</h5>
 <p>
-<code><font size="+1">JS9.Send(msg, obj, cb)</font></code>
+<code class="api">JS9.Send(msg, obj, cb)</code>
 <p>
 where:
 <ul>
@@ -3611,7 +3615,7 @@ server returns a list of available analysis tasks in json format.
 
 <h5 id="JS9.AddDivs">Add a JS9 display div and/or associated plugins</h5>
 <p>
-<code><font size="+1">JS9.AddDivs(id1, id2, ...)</font></code>
+<code class="api">JS9.AddDivs(id1, id2, ...)</code>
 <p>
 where:
 <ul>
@@ -3643,7 +3647,7 @@ light-weight or completely new window.
 
 <h5 id="JS9.InstantiatePlugins">Instantiate plugins on this web page</h5>
 <p>
-<code><font size="+1">JS9.InstantiatePlugins()</font></code>
+<code class="api">JS9.InstantiatePlugins()</code>
 <p>
 Normally, JS9 will instantiate all of its plugins automatically once the page
 is loaded and ready: internally, jQuery $(document).ready() calls JS9.init().
@@ -3669,7 +3673,7 @@ that we can gain a better understanding of what is required in these cases.
 
 <h5 id="JS9.LoadAuxFile">Load an auxiliary file</h5>
 <p>
-<code><font size="+1">JS9.LoadAuxFile(name, func)</font></code>
+<code class="api">JS9.LoadAuxFile(name, func)</code>
 <p>
 where:
 <ul>

--- a/help/publicapi.html
+++ b/help/publicapi.html
@@ -3082,7 +3082,6 @@ the <b>mustExist</b> parameter is explicitly set to false (i.e., the default
 is that the id must exist).
 
 <h5 id="JS9.ResizeDisplay">Resize the JS9 Display</h5>
-</p>
 <p>
 <code class="api">JS9.ResizeDisplay(dname, width, height, opts)</code>
 <p>

--- a/help/publicapi.html
+++ b/help/publicapi.html
@@ -3764,9 +3764,8 @@ that we can continue to think about what is required for their support.
 The JS9 Public API is meant to be stable and well-documented. If we are
 forced to make an incompatible change to the API, it will be documented here.
 
-<p><font size="+1"><b><u>
-20151218: OpenFileMenu and OpenRegionsMenu don't require a display argument
-</u></b></font>
+<h5>20151218: OpenFileMenu and OpenRegionsMenu don't require a display argument</h5>
+
 <p>
 The routines
 <a href="#JS9.OpenFileMenu"><b>OpenFileMenu()</b></a>
@@ -3777,9 +3776,8 @@ optional display object. This mistake has been corrected, with the
 result that both routines now target the default display, as expected,
 if no display is passed.
 
-<p><font size="+1"><b><u>
-20141117: The Set routines now return "OK" instead of true on success
-</u></b></font>
+<h5>20141117: The Set routines now return "OK" instead of true on success</h5>
+
 <p>
 The public Set routines
 (<a href="#JS9.SetZoom"><b>SetZoom()</b></a>,
@@ -3788,9 +3786,8 @@ were returning a boolean true when successful. This has been changed
 to "OK", to make it clear that the return value is a status value,
 not a boolean data value.
 
-<p><font size="+1"><b><u>
-20141028: callback function to RunAnalysis and SubmitAnalysis
-</u></b></font>
+<h5>20141028: callback function to RunAnalysis and SubmitAnalysis</h5>
+
 <p>
 Due to an oversight, the signature of the callback function supplied to
 <a href="#JS9.RunAnalysis"><b>RunAnalysis()</b></a>


### PR DESCRIPTION
Provide ids for the commands so that they can be linked to, and do so within the API.
